### PR TITLE
Add URL.createObjectURL mock in tests

### DIFF
--- a/tests/audio/AudioPlayer.test.js
+++ b/tests/audio/AudioPlayer.test.js
@@ -14,6 +14,8 @@ describe('AudioPlayer', () => {
 
     global.Audio = jest.fn(() => mockAudio);
 
+    global.URL.createObjectURL = jest.fn(() => 'blob:mock');
+
     mockCtx = {
       createMediaElementSource: jest.fn(() => ({ connect: jest.fn() })),
       state: 'running',
@@ -21,6 +23,10 @@ describe('AudioPlayer', () => {
     };
     global.AudioContext = jest.fn(() => mockCtx);
     player = new AudioPlayer();
+  });
+
+  afterEach(() => {
+    delete global.URL.createObjectURL;
   });
 
   test('loads only audio files', () => {


### PR DESCRIPTION
## Summary
- mock `URL.createObjectURL` in `AudioPlayer` tests
- clean up the mock in `afterEach`

## Testing
- `npm test` *(fails: Missing the native OfflineAudioContext constructor)*

------
https://chatgpt.com/codex/tasks/task_e_68471944b78883309505ba86c1e306b3