### PR TITLE
Add real-time rendering settings panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,24 @@
     <button id="playBtn" disabled>Play</button>
     <button id="stopBtn" disabled>Stop</button>
   </div>
+  <div id="settingsPanel">
+    <label>Color Mode
+      <select id="colorMode">
+        <option value="Rainbow">Rainbow</option>
+        <option value="Bass">Bass-colored</option>
+        <option value="White">Fixed White</option>
+      </select>
+    </label>
+    <label>Intensity
+      <input type="range" id="intensity" min="0.5" max="2" step="0.1" value="1" />
+    </label>
+    <label>Smoothing
+      <input type="range" id="smoothing" min="0" max="1" step="0.05" value="0.2" />
+    </label>
+    <label>
+      <input type="checkbox" id="strobe" /> Strobe on Beat
+    </label>
+  </div>
   <canvas id="canvas"></canvas>
   <script type="module" src="/src/main.js"></script>
 </body>

--- a/src/core/AppController.js
+++ b/src/core/AppController.js
@@ -3,11 +3,19 @@ import AudioAnalyzer from '../audio/AudioAnalyzer.js';
 import VisualizerCanvas from '../render/VisualizerCanvas.js';
 import SceneConfig from '../render/SceneConfig.js';
 import Controls from '../ui/Controls.js';
+import SettingsPanel from '../ui/SettingsPanel.js';
 
 export default class AppController {
   constructor(elements) {
-    const { fileInput, playBtn, stopBtn, canvas } = elements;
+    const { fileInput, playBtn, stopBtn, canvas, settingsPanel } = elements;
     this.controls = new Controls(fileInput, playBtn, stopBtn);
+    this.settings = {
+      colorMode: 'Rainbow',
+      intensity: 1,
+      smoothing: 0.2,
+      strobe: false,
+    };
+    new SettingsPanel(settingsPanel, this.settings);
     this.player = new AudioPlayer();
     this.analyzer = new AudioAnalyzer(this.player.audioCtx, SceneConfig.NUM_BARS);
     this.visualizer = new VisualizerCanvas(canvas, SceneConfig.NUM_BARS);
@@ -24,7 +32,7 @@ export default class AppController {
     this.controls.bindPlay(() => {
       this.player.play();
       if (!this.visualizer.animationId) {
-        this.visualizer.start(() => this.analyzer.getFrequencyBuckets());
+        this.visualizer.start(() => this.analyzer.getFrequencyBuckets(), this.settings);
       }
     });
     this.controls.bindStop(() => {

--- a/src/main.js
+++ b/src/main.js
@@ -6,6 +6,7 @@ window.addEventListener('DOMContentLoaded', () => {
     playBtn: document.getElementById('playBtn'),
     stopBtn: document.getElementById('stopBtn'),
     canvas: document.getElementById('canvas'),
+    settingsPanel: document.getElementById('settingsPanel'),
   };
   new AppController(elements);
 });

--- a/src/render/VisualizerCanvas.js
+++ b/src/render/VisualizerCanvas.js
@@ -1,29 +1,54 @@
+import applySmoothing from './applySmoothing.js';
+
 export default class VisualizerCanvas {
   constructor(canvas, numBars) {
     this.canvas = canvas;
     this.ctx = canvas.getContext('2d');
     this.numBars = numBars;
     this.animationId = null;
+    this.prev = new Array(numBars).fill(0);
+    this.prevBeat = false;
   }
 
-  drawFrame(buckets) {
+  drawFrame(buckets, settings) {
     const width = this.canvas.clientWidth;
     const height = this.canvas.clientHeight;
     this.canvas.width = width;
     this.canvas.height = height;
+    const { colorMode, intensity, smoothing, strobe } = settings;
+
+    const beat = buckets[0] > 0.8 && !this.prevBeat;
+    this.prevBeat = buckets[0] > 0.8;
+
+    if (strobe && beat) {
+      this.ctx.fillStyle = 'white';
+      this.ctx.fillRect(0, 0, width, height);
+      return;
+    }
+
     this.ctx.clearRect(0, 0, width, height);
     const barWidth = width / this.numBars;
     for (let i = 0; i < this.numBars; i++) {
-      const magnitude = buckets[i]; // already normalized 0-1
-      const barHeight = magnitude * height;
-      this.ctx.fillStyle = `hsl(${i * 40}, 100%, ${50 + magnitude * 50}%)`;
+      const current = Math.min(buckets[i] * intensity, 1);
+      const mag = applySmoothing(this.prev[i], current, smoothing);
+      this.prev[i] = mag;
+      const barHeight = mag * height;
+
+      let fill = 'white';
+      if (colorMode === 'Rainbow') {
+        fill = `hsl(${i * 40}, 100%, ${50 + mag * 50}%)`;
+      } else if (colorMode === 'Bass') {
+        const hue = buckets[0] * 200;
+        fill = `hsl(${hue}, 100%, 50%)`;
+      }
+      this.ctx.fillStyle = fill;
       this.ctx.fillRect(i * barWidth, height - barHeight, barWidth - 2, barHeight);
     }
   }
 
-  start(drawFn) {
+  start(drawFn, settings) {
     const loop = () => {
-      this.drawFrame(drawFn());
+      this.drawFrame(drawFn(), settings);
       this.animationId = requestAnimationFrame(loop);
     };
     loop();

--- a/src/render/applySmoothing.js
+++ b/src/render/applySmoothing.js
@@ -1,0 +1,4 @@
+// Exponential smoothing for bar animations
+export default function applySmoothing(prev, current, strength) {
+  return prev * (1 - strength) + current * strength;
+}

--- a/src/ui/SettingsPanel.js
+++ b/src/ui/SettingsPanel.js
@@ -1,0 +1,31 @@
+export default class SettingsPanel {
+  constructor(container, settings) {
+    this.settings = settings;
+    this.container = container;
+    this.init();
+  }
+
+  // Setup listeners to keep settings in sync with UI controls
+  init() {
+    this.colorMode = this.container.querySelector('#colorMode');
+    this.intensity = this.container.querySelector('#intensity');
+    this.smoothing = this.container.querySelector('#smoothing');
+    this.strobe = this.container.querySelector('#strobe');
+
+    const update = () => {
+      this.settings.colorMode = this.colorMode.value;
+      this.settings.intensity = parseFloat(this.intensity.value);
+      this.settings.smoothing = parseFloat(this.smoothing.value);
+      this.settings.strobe = this.strobe.checked;
+    };
+
+    ['change', 'input'].forEach(evt => {
+      this.colorMode.addEventListener(evt, update);
+      this.intensity.addEventListener(evt, update);
+      this.smoothing.addEventListener(evt, update);
+    });
+    this.strobe.addEventListener('change', update);
+
+    update();
+  }
+}

--- a/style.css
+++ b/style.css
@@ -13,6 +13,23 @@ body {
   margin-top: 20px;
 }
 
+#settingsPanel {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 10px;
+}
+
+#settingsPanel label {
+  display: flex;
+  justify-content: space-between;
+  width: 200px;
+}
+
+#settingsPanel input[type='range'] {
+  width: 120px;
+}
+
 canvas {
   flex: 1;
   width: 100%;

--- a/tests/render/VisualizerCanvas.test.js
+++ b/tests/render/VisualizerCanvas.test.js
@@ -8,6 +8,7 @@ describe('VisualizerCanvas', () => {
   test('drawFrame runs without errors', () => {
     const canvas = document.getElementById('c');
     const vis = new VisualizerCanvas(canvas, 2);
-    expect(() => vis.drawFrame([0.5, 1])).not.toThrow();
+    const settings = { colorMode: 'Rainbow', intensity: 1, smoothing: 0.2, strobe: false };
+    expect(() => vis.drawFrame([0.5, 1], settings)).not.toThrow();
   });
 });

--- a/tests/render/applySmoothing.test.js
+++ b/tests/render/applySmoothing.test.js
@@ -1,0 +1,8 @@
+import applySmoothing from '../../src/render/applySmoothing.js';
+
+describe('applySmoothing', () => {
+  test('interpolates between values', () => {
+    expect(applySmoothing(0, 1, 0.5)).toBeCloseTo(0.5);
+    expect(applySmoothing(1, 0, 0.2)).toBeCloseTo(0.8);
+  });
+});


### PR DESCRIPTION
## Summary
- add a small panel in `index.html` with color mode, intensity, smoothing and strobe controls
- style the panel via `style.css`
- implement `SettingsPanel` UI class to keep `settings` state updated
- update `AppController` and `main.js` to pass settings to the visualizer
- extend `VisualizerCanvas` to honor settings and apply smoothing/beat strobe
- add small helper `applySmoothing` with unit tests
- update tests for new API

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68471b41182c833089615372707e32f3