### PR TITLE
Add cue logging and beat detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,8 @@
     <input type="file" id="fileInput" accept="audio/*" />
     <button id="playBtn" disabled>Play</button>
     <button id="stopBtn" disabled>Stop</button>
+    <button id="downloadCueBtn" disabled>Download Cue JSON</button>
+    <label><input type="checkbox" id="strobeToggle"> Strobe on Beat</label>
   </div>
   <canvas id="canvas"></canvas>
   <script type="module" src="/src/main.js"></script>

--- a/src/audio/BeatDetector.js
+++ b/src/audio/BeatDetector.js
@@ -1,0 +1,32 @@
+export default class BeatDetector {
+  constructor({ historySize = 60, threshold = 1.2, cooldown = 200 } = {}) {
+    this.historySize = historySize;
+    this.threshold = threshold;
+    this.cooldown = cooldown;
+    this.energyHistory = [];
+    this.lastBeatTime = -Infinity;
+  }
+
+  // Process band data and return true if a beat is detected
+  process(bands, timestampMs) {
+    const energy = bands.reduce((a, b) => a + b, 0) / bands.length;
+    const avgEnergy =
+      this.energyHistory.reduce((a, b) => a + b, 0) /
+      (this.energyHistory.length || 1);
+    this.energyHistory.push(energy);
+    if (this.energyHistory.length > this.historySize) {
+      this.energyHistory.shift();
+    }
+    if (this.energyHistory.length === 1) {
+      return false;
+    }
+    if (timestampMs - this.lastBeatTime < this.cooldown) {
+      return false;
+    }
+    if (energy > avgEnergy * this.threshold) {
+      this.lastBeatTime = timestampMs;
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/core/AppController.js
+++ b/src/core/AppController.js
@@ -1,16 +1,20 @@
 import AudioPlayer from '../audio/AudioPlayer.js';
 import AudioAnalyzer from '../audio/AudioAnalyzer.js';
+import BeatDetector from '../audio/BeatDetector.js';
 import VisualizerCanvas from '../render/VisualizerCanvas.js';
 import SceneConfig from '../render/SceneConfig.js';
 import Controls from '../ui/Controls.js';
+import CueLogger from './CueLogger.js';
 
 export default class AppController {
   constructor(elements) {
-    const { fileInput, playBtn, stopBtn, canvas } = elements;
-    this.controls = new Controls(fileInput, playBtn, stopBtn);
+    const { fileInput, playBtn, stopBtn, downloadCueBtn, strobeToggle, canvas } = elements;
+    this.controls = new Controls(fileInput, playBtn, stopBtn, downloadCueBtn, strobeToggle);
     this.player = new AudioPlayer();
     this.analyzer = new AudioAnalyzer(this.player.audioCtx, SceneConfig.NUM_BARS);
     this.visualizer = new VisualizerCanvas(canvas, SceneConfig.NUM_BARS);
+    this.logger = new CueLogger();
+    this.beatDetector = new BeatDetector();
     this.bindEvents();
   }
 
@@ -21,15 +25,31 @@ export default class AppController {
       this.analyzer.connect(this.player.source);
       this.controls.enable();
     });
+
     this.controls.bindPlay(() => {
+      this.logger.start();
+      this.controls.setDownloadEnabled(false);
       this.player.play();
       if (!this.visualizer.animationId) {
-        this.visualizer.start(() => this.analyzer.getFrequencyBuckets());
+        this.visualizer.start(() => {
+          const bands = this.analyzer.getFrequencyBuckets();
+          const now = performance.now();
+          this.logger.addEntry(now, bands);
+          if (this.beatDetector.process(bands, now) && this.controls.isStrobeEnabled()) {
+            this.visualizer.flash();
+          }
+          return bands;
+        });
       }
     });
+
     this.controls.bindStop(() => {
       this.player.stop();
       this.visualizer.stop();
+      this.controls.setDownloadEnabled(true);
     });
+
+    this.controls.bindDownload(() => this.logger.download());
+    this.controls.bindStrobeToggle(() => {});
   }
 }

--- a/src/core/CueLogger.js
+++ b/src/core/CueLogger.js
@@ -1,0 +1,41 @@
+export default class CueLogger {
+  constructor() {
+    this.log = [];
+    this.startTime = null;
+  }
+
+  // Reset the log and mark the start time
+  start() {
+    this.log = [];
+    this.startTime = performance.now();
+  }
+
+  // Append a cue entry
+  addEntry(timestampMs, bands) {
+    if (this.startTime === null) return;
+    const entry = {
+      timestamp: timestampMs - this.startTime,
+      bands: bands.map(v => Math.round(v * 100) / 100),
+    };
+    this.log.push(entry);
+  }
+
+  // Retrieve log data
+  getLog() {
+    return this.log;
+  }
+
+  // Trigger download of the log as a file
+  download() {
+    const date = new Date().toISOString().replace(/:/g, '-');
+    const blob = new Blob([JSON.stringify(this.log)], {
+      type: 'application/json',
+    });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `visual_cue_${date}.json`;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,8 @@ window.addEventListener('DOMContentLoaded', () => {
     fileInput: document.getElementById('fileInput'),
     playBtn: document.getElementById('playBtn'),
     stopBtn: document.getElementById('stopBtn'),
+    downloadCueBtn: document.getElementById('downloadCueBtn'),
+    strobeToggle: document.getElementById('strobeToggle'),
     canvas: document.getElementById('canvas'),
   };
   new AppController(elements);

--- a/src/render/VisualizerCanvas.js
+++ b/src/render/VisualizerCanvas.js
@@ -4,6 +4,7 @@ export default class VisualizerCanvas {
     this.ctx = canvas.getContext('2d');
     this.numBars = numBars;
     this.animationId = null;
+    this.shouldFlash = false;
   }
 
   drawFrame(buckets) {
@@ -19,6 +20,11 @@ export default class VisualizerCanvas {
       this.ctx.fillStyle = `hsl(${i * 40}, 100%, ${50 + magnitude * 50}%)`;
       this.ctx.fillRect(i * barWidth, height - barHeight, barWidth - 2, barHeight);
     }
+    if (this.shouldFlash) {
+      this.ctx.fillStyle = 'rgba(255,255,255,0.7)';
+      this.ctx.fillRect(0, 0, width, height);
+      this.shouldFlash = false;
+    }
   }
 
   start(drawFn) {
@@ -33,5 +39,9 @@ export default class VisualizerCanvas {
     cancelAnimationFrame(this.animationId);
     this.animationId = null;
     this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+  }
+
+  flash() {
+    this.shouldFlash = true;
   }
 }

--- a/src/ui/Controls.js
+++ b/src/ui/Controls.js
@@ -1,8 +1,10 @@
 export default class Controls {
-  constructor(fileInput, playBtn, stopBtn) {
+  constructor(fileInput, playBtn, stopBtn, downloadBtn, strobeToggle) {
     this.fileInput = fileInput;
     this.playBtn = playBtn;
     this.stopBtn = stopBtn;
+    this.downloadBtn = downloadBtn;
+    this.strobeToggle = strobeToggle;
   }
 
   bindLoad(handler) {
@@ -18,6 +20,22 @@ export default class Controls {
 
   bindStop(handler) {
     this.stopBtn.addEventListener('click', handler);
+  }
+
+  bindDownload(handler) {
+    this.downloadBtn.addEventListener('click', handler);
+  }
+
+  bindStrobeToggle(handler) {
+    this.strobeToggle.addEventListener('change', handler);
+  }
+
+  isStrobeEnabled() {
+    return this.strobeToggle.checked;
+  }
+
+  setDownloadEnabled(enabled) {
+    this.downloadBtn.disabled = !enabled;
   }
 
   enable() {

--- a/tests/audio/BeatDetector.test.js
+++ b/tests/audio/BeatDetector.test.js
@@ -1,0 +1,19 @@
+import BeatDetector from '../../src/audio/BeatDetector.js';
+
+describe('BeatDetector', () => {
+  test('detects energy spike as beat and respects cooldown', () => {
+    const det = new BeatDetector({ historySize: 3, threshold: 1.2, cooldown: 200 });
+    // warm up history with constant energy
+    expect(det.process([0.5, 0.5], 0)).toBe(false);
+    expect(det.process([0.5, 0.5], 16)).toBe(false);
+    expect(det.process([0.5, 0.5], 32)).toBe(false);
+    // big spike
+    expect(det.process([1, 1], 48)).toBe(true);
+    // within cooldown
+    expect(det.process([1, 1], 100)).toBe(false);
+    // baseline energy to adjust average
+    expect(det.process([0.4, 0.4], 200)).toBe(false);
+    // after cooldown and with spike
+    expect(det.process([1, 1], 300)).toBe(true);
+  });
+});

--- a/tests/core/CueLogger.test.js
+++ b/tests/core/CueLogger.test.js
@@ -1,0 +1,29 @@
+import CueLogger from '../../src/core/CueLogger.js';
+
+describe('CueLogger', () => {
+  let nowMock;
+  beforeEach(() => {
+    nowMock = jest.fn(() => 1000);
+    global.performance.now = nowMock;
+  });
+
+  test('records entries with relative timestamps', () => {
+    const logger = new CueLogger();
+    logger.start();
+    global.performance.now.mockReturnValue(1010);
+    logger.addEntry(performance.now(), [0.1, 0.2]);
+    const log = logger.getLog();
+    expect(log.length).toBe(1);
+    expect(log[0].timestamp).toBe(10);
+    expect(log[0].bands).toEqual([0.1, 0.2]);
+  });
+
+  test('reset clears log', () => {
+    const logger = new CueLogger();
+    logger.start();
+    logger.addEntry(performance.now(), [0.1]);
+    expect(logger.getLog().length).toBe(1);
+    logger.start();
+    expect(logger.getLog().length).toBe(0);
+  });
+});

--- a/tests/render/VisualizerCanvas.test.js
+++ b/tests/render/VisualizerCanvas.test.js
@@ -10,4 +10,11 @@ describe('VisualizerCanvas', () => {
     const vis = new VisualizerCanvas(canvas, 2);
     expect(() => vis.drawFrame([0.5, 1])).not.toThrow();
   });
+
+  test('flash overlays white rectangle for one frame', () => {
+    const canvas = document.getElementById('c');
+    const vis = new VisualizerCanvas(canvas, 2);
+    vis.flash();
+    expect(() => vis.drawFrame([0, 0])).not.toThrow();
+  });
 });


### PR DESCRIPTION
## Summary
- log cue stream to JSON in CueLogger
- implement BeatDetector for simple beat recognition
- flash canvas on beats and add strobe toggle
- add download cue button and hook up controls
- cover new modules with Jest tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68471b881eb083308eef6422990a27e0