### PR TITLE
Add simple beat detection strobe flash

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <input type="file" id="fileInput" accept="audio/*" />
     <button id="playBtn" disabled>Play</button>
     <button id="stopBtn" disabled>Stop</button>
+    <label><input type="checkbox" id="strobeToggle" checked /> Strobe</label>
   </div>
   <canvas id="canvas"></canvas>
   <script type="module" src="/src/main.js"></script>

--- a/src/audio/BeatDetector.js
+++ b/src/audio/BeatDetector.js
@@ -1,0 +1,29 @@
+export default class BeatDetector {
+  constructor({ historySize = 43, threshold = 1.3, cooldown = 300, timeFn = () => performance.now() } = {}) {
+    this.historySize = historySize;
+    this.threshold = threshold;
+    this.cooldown = cooldown;
+    this.timeFn = timeFn;
+    this.history = [];
+    this.lastBeat = -Infinity;
+  }
+
+  /**
+   * Update detector with new energy buckets and detect a beat.
+   * @param {number[]} buckets - normalized energy values
+   * @returns {boolean} true if a beat is detected
+   */
+  update(buckets) {
+    if (!buckets || buckets.length === 0) return false;
+    const energy = buckets.reduce((s, v) => s + v, 0) / buckets.length;
+    this.history.push(energy);
+    if (this.history.length > this.historySize) this.history.shift();
+    const avg = this.history.reduce((s, v) => s + v, 0) / this.history.length;
+    const now = this.timeFn();
+    if (energy > avg * this.threshold && now - this.lastBeat >= this.cooldown) {
+      this.lastBeat = now;
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/core/AppController.js
+++ b/src/core/AppController.js
@@ -1,16 +1,18 @@
 import AudioPlayer from '../audio/AudioPlayer.js';
 import AudioAnalyzer from '../audio/AudioAnalyzer.js';
+import BeatDetector from '../audio/BeatDetector.js';
 import VisualizerCanvas from '../render/VisualizerCanvas.js';
 import SceneConfig from '../render/SceneConfig.js';
 import Controls from '../ui/Controls.js';
 
 export default class AppController {
   constructor(elements) {
-    const { fileInput, playBtn, stopBtn, canvas } = elements;
-    this.controls = new Controls(fileInput, playBtn, stopBtn);
+    const { fileInput, playBtn, stopBtn, strobeToggle, canvas } = elements;
+    this.controls = new Controls(fileInput, playBtn, stopBtn, strobeToggle);
     this.player = new AudioPlayer();
     this.analyzer = new AudioAnalyzer(this.player.audioCtx, SceneConfig.NUM_BARS);
     this.visualizer = new VisualizerCanvas(canvas, SceneConfig.NUM_BARS);
+    this.beatDetector = new BeatDetector();
     this.bindEvents();
   }
 
@@ -24,12 +26,23 @@ export default class AppController {
     this.controls.bindPlay(() => {
       this.player.play();
       if (!this.visualizer.animationId) {
-        this.visualizer.start(() => this.analyzer.getFrequencyBuckets());
+        this.visualizer.start(
+          () => this.analyzer.getFrequencyBuckets(),
+          buckets => {
+            if (this.beatDetector.update(buckets)) {
+              this.visualizer.triggerFlash();
+            }
+          }
+        );
       }
     });
     this.controls.bindStop(() => {
       this.player.stop();
       this.visualizer.stop();
+    });
+
+    this.controls.bindStrobeChange(enabled => {
+      this.visualizer.setStrobe(enabled);
     });
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ window.addEventListener('DOMContentLoaded', () => {
     fileInput: document.getElementById('fileInput'),
     playBtn: document.getElementById('playBtn'),
     stopBtn: document.getElementById('stopBtn'),
+    strobeToggle: document.getElementById('strobeToggle'),
     canvas: document.getElementById('canvas'),
   };
   new AppController(elements);

--- a/src/render/VisualizerCanvas.js
+++ b/src/render/VisualizerCanvas.js
@@ -4,6 +4,8 @@ export default class VisualizerCanvas {
     this.ctx = canvas.getContext('2d');
     this.numBars = numBars;
     this.animationId = null;
+    this.flashActive = false;
+    this.strobeEnabled = true;
   }
 
   drawFrame(buckets) {
@@ -19,11 +21,18 @@ export default class VisualizerCanvas {
       this.ctx.fillStyle = `hsl(${i * 40}, 100%, ${50 + magnitude * 50}%)`;
       this.ctx.fillRect(i * barWidth, height - barHeight, barWidth - 2, barHeight);
     }
+    if (this.flashActive) {
+      this.ctx.fillStyle = 'rgba(255,255,255,0.7)';
+      this.ctx.fillRect(0, 0, width, height);
+      this.flashActive = false;
+    }
   }
 
-  start(drawFn) {
+  start(drawFn, onFrame) {
     const loop = () => {
-      this.drawFrame(drawFn());
+      const buckets = drawFn();
+      if (onFrame) onFrame(buckets);
+      this.drawFrame(buckets);
       this.animationId = requestAnimationFrame(loop);
     };
     loop();
@@ -33,5 +42,17 @@ export default class VisualizerCanvas {
     cancelAnimationFrame(this.animationId);
     this.animationId = null;
     this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+  }
+
+  /** Enable or disable strobe flashes */
+  setStrobe(enabled) {
+    this.strobeEnabled = enabled;
+  }
+
+  /** Trigger a flash overlay on next frame */
+  triggerFlash() {
+    if (this.strobeEnabled) {
+      this.flashActive = true;
+    }
   }
 }

--- a/src/ui/Controls.js
+++ b/src/ui/Controls.js
@@ -1,8 +1,9 @@
 export default class Controls {
-  constructor(fileInput, playBtn, stopBtn) {
+  constructor(fileInput, playBtn, stopBtn, strobeToggle) {
     this.fileInput = fileInput;
     this.playBtn = playBtn;
     this.stopBtn = stopBtn;
+    this.strobeToggle = strobeToggle;
   }
 
   bindLoad(handler) {
@@ -18,6 +19,13 @@ export default class Controls {
 
   bindStop(handler) {
     this.stopBtn.addEventListener('click', handler);
+  }
+
+  bindStrobeChange(handler) {
+    if (this.strobeToggle) {
+      this.strobeToggle.addEventListener('change', e => handler(e.target.checked));
+      handler(this.strobeToggle.checked);
+    }
   }
 
   enable() {

--- a/tests/audio/BeatDetector.test.js
+++ b/tests/audio/BeatDetector.test.js
@@ -1,0 +1,14 @@
+import BeatDetector from '../../src/audio/BeatDetector.js';
+
+describe('BeatDetector', () => {
+  test('detects spikes and respects cooldown', () => {
+    const times = [0, 100, 200, 400];
+    let idx = 0;
+    const detector = new BeatDetector({ historySize: 3, threshold: 1.2, cooldown: 300, timeFn: () => times[idx++] });
+
+    expect(detector.update([0, 0, 0])).toBe(false); // initial silence
+    expect(detector.update([1, 1, 1])).toBe(true);  // first spike triggers
+    expect(detector.update([0, 0, 0])).toBe(false); // low energy
+    expect(detector.update([1, 1, 1])).toBe(true);  // second spike after cooldown
+  });
+});

--- a/tests/render/VisualizerCanvas.test.js
+++ b/tests/render/VisualizerCanvas.test.js
@@ -10,4 +10,13 @@ describe('VisualizerCanvas', () => {
     const vis = new VisualizerCanvas(canvas, 2);
     expect(() => vis.drawFrame([0.5, 1])).not.toThrow();
   });
+
+  test('triggerFlash sets flag and clears after draw', () => {
+    const canvas = document.getElementById('c');
+    const vis = new VisualizerCanvas(canvas, 2);
+    vis.triggerFlash();
+    expect(vis.flashActive).toBe(true);
+    vis.drawFrame([0, 0]);
+    expect(vis.flashActive).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- add new `BeatDetector` utility for simple energy spike detection
- flash the canvas when a beat is detected
- add strobe toggle control and wire into AppController
- expose flash helpers in `VisualizerCanvas`
- test beat detection and flash logic

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68471bd304e483308124118c2f1b66a5