### PR TITLE
Add simple beat detector with strobe flash

### DIFF
--- a/src/audio/BeatDetector.js
+++ b/src/audio/BeatDetector.js
@@ -1,0 +1,33 @@
+// Simple energy-based beat detection
+export default class BeatDetector {
+  constructor(options = {}) {
+    this.historySize = options.historySize ?? 43; // ~0.7s of history at 60fps
+    this.threshold = options.threshold ?? 1.3; // energy multiplier to trigger
+    this.cooldown = options.cooldown ?? 300; // ms between beats
+    this.history = new Array(this.historySize).fill(0);
+    this.index = 0;
+    this.filled = false;
+    this.lastBeat = -Infinity;
+  }
+
+  /**
+   * Update detector with latest normalized energy level.
+   * @param {number} energy value between 0 and 1
+   * @param {number} [now=Date.now()] timestamp for cooldown check
+   * @returns {boolean} true if beat detected
+   */
+  update(energy, now = Date.now()) {
+    const used = this.filled ? this.historySize : this.index || 1;
+    const avg = this.history.slice(0, used).reduce((s, v) => s + v, 0) / used;
+    this.history[this.index] = energy;
+    this.index = (this.index + 1) % this.historySize;
+    if (this.index === 0) this.filled = true;
+
+    if (now - this.lastBeat < this.cooldown) return false;
+    if (this.filled && energy > avg * this.threshold) {
+      this.lastBeat = now;
+      return true;
+    }
+    return false;
+  }
+}

--- a/src/render/VisualizerCanvas.js
+++ b/src/render/VisualizerCanvas.js
@@ -1,4 +1,5 @@
 import applySmoothing from './applySmoothing.js';
+import BeatDetector from '../audio/BeatDetector.js';
 
 export default class VisualizerCanvas {
   constructor(canvas, numBars) {
@@ -7,7 +8,7 @@ export default class VisualizerCanvas {
     this.numBars = numBars;
     this.animationId = null;
     this.prev = new Array(numBars).fill(0);
-    this.prevBeat = false;
+    this.beatDetector = new BeatDetector();
   }
 
   drawFrame(buckets, settings) {
@@ -17,8 +18,8 @@ export default class VisualizerCanvas {
     this.canvas.height = height;
     const { colorMode, intensity, smoothing, strobe } = settings;
 
-    const beat = buckets[0] > 0.8 && !this.prevBeat;
-    this.prevBeat = buckets[0] > 0.8;
+    const energy = buckets.reduce((s, v) => s + v, 0) / buckets.length;
+    const beat = this.beatDetector.update(energy);
 
     if (strobe && beat) {
       this.ctx.fillStyle = 'white';

--- a/tests/audio/BeatDetector.test.js
+++ b/tests/audio/BeatDetector.test.js
@@ -1,0 +1,24 @@
+import BeatDetector from '../../src/audio/BeatDetector.js';
+
+describe('BeatDetector', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(0);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test('detects rising energy with cooldown', () => {
+    const detector = new BeatDetector({ historySize: 4, threshold: 1.5, cooldown: 200 });
+    for (let i = 0; i < 4; i++) {
+      expect(detector.update(0.1, Date.now())).toBe(false);
+      jest.advanceTimersByTime(16);
+    }
+    jest.advanceTimersByTime(16);
+    expect(detector.update(0.3, Date.now())).toBe(true);
+    jest.advanceTimersByTime(16);
+    expect(detector.update(0.3, Date.now())).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- create `BeatDetector` helper for energy-based beat detection
- flash canvas when beat detected using the detector
- test beat detection logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68488e041d208330ae29e9266d7c8280