### PR TITLE
Add FPS counter

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,6 +30,7 @@
       <input type="checkbox" id="strobe" /> Strobe on Beat
     </label>
   </div>
+  <div id="fpsDisplay">FPS: 0</div>
   <canvas id="canvas"></canvas>
   <script type="module" src="/src/main.js"></script>
 </body>

--- a/src/core/AppController.js
+++ b/src/core/AppController.js
@@ -4,10 +4,11 @@ import VisualizerCanvas from '../render/VisualizerCanvas.js';
 import SceneConfig from '../render/SceneConfig.js';
 import Controls from '../ui/Controls.js';
 import SettingsPanel from '../ui/SettingsPanel.js';
+import FpsCounter from '../ui/FpsCounter.js';
 
 export default class AppController {
   constructor(elements) {
-    const { fileInput, playBtn, stopBtn, canvas, settingsPanel } = elements;
+    const { fileInput, playBtn, stopBtn, canvas, settingsPanel, fpsDisplay } = elements;
     this.controls = new Controls(fileInput, playBtn, stopBtn);
     this.settings = {
       colorMode: 'Rainbow',
@@ -19,6 +20,7 @@ export default class AppController {
     this.player = new AudioPlayer();
     this.analyzer = new AudioAnalyzer(this.player.audioCtx, SceneConfig.NUM_BARS);
     this.visualizer = new VisualizerCanvas(canvas, SceneConfig.NUM_BARS);
+    this.fpsCounter = new FpsCounter(fpsDisplay);
     this.bindEvents();
   }
 
@@ -32,12 +34,18 @@ export default class AppController {
     this.controls.bindPlay(() => {
       this.player.play();
       if (!this.visualizer.animationId) {
-        this.visualizer.start(() => this.analyzer.getFrequencyBuckets(), this.settings);
+        this.fpsCounter.reset();
+        this.visualizer.start(
+          () => this.analyzer.getFrequencyBuckets(),
+          this.settings,
+          this.fpsCounter
+        );
       }
     });
     this.controls.bindStop(() => {
       this.player.stop();
       this.visualizer.stop();
+      this.fpsCounter.reset();
     });
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ window.addEventListener('DOMContentLoaded', () => {
     stopBtn: document.getElementById('stopBtn'),
     canvas: document.getElementById('canvas'),
     settingsPanel: document.getElementById('settingsPanel'),
+    fpsDisplay: document.getElementById('fpsDisplay'),
   };
   new AppController(elements);
 });

--- a/src/render/VisualizerCanvas.js
+++ b/src/render/VisualizerCanvas.js
@@ -46,8 +46,9 @@ export default class VisualizerCanvas {
     }
   }
 
-  start(drawFn, settings) {
+  start(drawFn, settings, fpsCounter = null) {
     const loop = () => {
+      if (fpsCounter) fpsCounter.tick();
       this.drawFrame(drawFn(), settings);
       this.animationId = requestAnimationFrame(loop);
     };

--- a/src/ui/FpsCounter.js
+++ b/src/ui/FpsCounter.js
@@ -1,0 +1,29 @@
+export default class FpsCounter {
+  constructor(element, perf = performance) {
+    this.element = element;
+    this.perf = perf;
+    this.frames = 0;
+    this.lastTime = this.perf.now();
+  }
+
+  /**
+   * Increment frame count and update DOM when a second passes.
+   */
+  tick() {
+    this.frames += 1;
+    const now = this.perf.now();
+    const delta = now - this.lastTime;
+    if (delta >= 1000) {
+      const fps = Math.round((this.frames * 1000) / delta);
+      this.element.textContent = `FPS: ${fps}`;
+      this.frames = 0;
+      this.lastTime = now;
+    }
+  }
+
+  reset() {
+    this.frames = 0;
+    this.lastTime = this.perf.now();
+    this.element.textContent = 'FPS: 0';
+  }
+}

--- a/style.css
+++ b/style.css
@@ -7,6 +7,7 @@ body {
   flex-direction: column;
   align-items: center;
   height: 100vh;
+  position: relative;
 }
 
 #controls {
@@ -34,4 +35,14 @@ canvas {
   flex: 1;
   width: 100%;
   background-color: #000;
+}
+
+#fpsDisplay {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  background: rgba(0, 0, 0, 0.5);
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-size: 14px;
 }

--- a/tests/ui/FpsCounter.test.js
+++ b/tests/ui/FpsCounter.test.js
@@ -1,0 +1,25 @@
+import FpsCounter from '../../src/ui/FpsCounter.js';
+
+describe('FpsCounter', () => {
+  test('updates element after one second', () => {
+    const times = [0, 100, 200, 300, 400, 1000];
+    let idx = 0;
+    const perf = { now: () => times[idx++] };
+    document.body.innerHTML = '<div id="fps"></div>';
+    const el = document.getElementById('fps');
+    const counter = new FpsCounter(el, perf);
+    for (let i = 0; i < times.length; i++) {
+      counter.tick();
+    }
+    expect(el.textContent).toBe('FPS: 5');
+  });
+
+  test('reset clears text', () => {
+    document.body.innerHTML = '<div id="fps"></div>';
+    const el = document.getElementById('fps');
+    const counter = new FpsCounter(el, { now: () => 0 });
+    counter.tick();
+    counter.reset();
+    expect(el.textContent).toBe('FPS: 0');
+  });
+});


### PR DESCRIPTION
## Summary
- display an FPS counter on screen
- integrate FPS tracking into AppController and VisualizerCanvas
- style the FPS display element
- provide unit tests for the new FpsCounter utility

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68488eb3698c83308f4a1534eb9d4a38