### PR TITLE
Implement cue logging and beat detection

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     <input type="file" id="fileInput" accept="audio/*" />
     <button id="playBtn" disabled>Play</button>
     <button id="stopBtn" disabled>Stop</button>
+    <button id="downloadCue" disabled>Download Cue JSON</button>
   </div>
   <div id="settingsPanel">
     <label>Color Mode
@@ -27,7 +28,7 @@
       <input type="range" id="smoothing" min="0" max="1" step="0.05" value="0.2" />
     </label>
     <label>
-      <input type="checkbox" id="strobe" /> Strobe on Beat
+      <input type="checkbox" id="strobeToggle" /> Strobe on Beat
     </label>
   </div>
   <canvas id="canvas"></canvas>

--- a/src/audio/BeatDetector.js
+++ b/src/audio/BeatDetector.js
@@ -1,0 +1,18 @@
+export default class BeatDetector {
+  constructor(cooldownMs = 200) {
+    this.cooldownMs = cooldownMs;
+    this.energyHistory = [];
+    this.lastBeatTime = -Infinity;
+  }
+
+  // Update detector with new band values; returns true if a beat is detected
+  update(bandValues, time = performance.now()) {
+    const energy = bandValues.reduce((s, v) => s + v, 0) / bandValues.length;
+    if (this.energyHistory.length >= 60) this.energyHistory.shift();
+    this.energyHistory.push(energy);
+    const avg = this.energyHistory.reduce((s, v) => s + v, 0) / this.energyHistory.length;
+    const isBeat = energy > avg * 1.2 && (time - this.lastBeatTime) > this.cooldownMs;
+    if (isBeat) this.lastBeatTime = time;
+    return isBeat;
+  }
+}

--- a/src/core/AppController.js
+++ b/src/core/AppController.js
@@ -1,14 +1,16 @@
 import AudioPlayer from '../audio/AudioPlayer.js';
 import AudioAnalyzer from '../audio/AudioAnalyzer.js';
+import BeatDetector from '../audio/BeatDetector.js';
 import VisualizerCanvas from '../render/VisualizerCanvas.js';
 import SceneConfig from '../render/SceneConfig.js';
 import Controls from '../ui/Controls.js';
 import SettingsPanel from '../ui/SettingsPanel.js';
+import CueLogger from './CueLogger.js';
 
 export default class AppController {
   constructor(elements) {
-    const { fileInput, playBtn, stopBtn, canvas, settingsPanel } = elements;
-    this.controls = new Controls(fileInput, playBtn, stopBtn);
+    const { fileInput, playBtn, stopBtn, downloadBtn, canvas, settingsPanel } = elements;
+    this.controls = new Controls(fileInput, playBtn, stopBtn, downloadBtn);
     this.settings = {
       colorMode: 'Rainbow',
       intensity: 1,
@@ -19,6 +21,9 @@ export default class AppController {
     this.player = new AudioPlayer();
     this.analyzer = new AudioAnalyzer(this.player.audioCtx, SceneConfig.NUM_BARS);
     this.visualizer = new VisualizerCanvas(canvas, SceneConfig.NUM_BARS);
+    this.cueLogger = new CueLogger();
+    this.beatDetector = new BeatDetector();
+    this.animationId = null;
     this.bindEvents();
   }
 
@@ -28,16 +33,31 @@ export default class AppController {
       // Connect the player's source through the analyzer to the speakers
       this.analyzer.connect(this.player.source);
       this.controls.enable();
+      this.controls.setDownloadEnabled(true);
     });
     this.controls.bindPlay(() => {
       this.player.play();
+      this.cueLogger.reset();
       if (!this.visualizer.animationId) {
-        this.visualizer.start(() => this.analyzer.getFrequencyBuckets(), this.settings);
+        this.visualizer.start(
+          () => this.analyzer.getFrequencyBuckets(),
+          this.settings,
+          buckets => {
+            const beat = this.beatDetector.update(buckets);
+            this.cueLogger.logFrame(buckets);
+            return beat;
+          }
+        );
       }
+      this.controls.setDownloadEnabled(false);
     });
     this.controls.bindStop(() => {
       this.player.stop();
       this.visualizer.stop();
+      this.controls.setDownloadEnabled(true);
+    });
+    this.controls.bindDownload(() => {
+      this.cueLogger.download();
     });
   }
 }

--- a/src/core/CueLogger.js
+++ b/src/core/CueLogger.js
@@ -1,0 +1,39 @@
+export default class CueLogger {
+  constructor(maxEntries = 36000) {
+    this.maxEntries = maxEntries;
+    this.reset();
+  }
+
+  // Reset log and mark a new start time
+  reset(startTime = performance.now()) {
+    this.startTime = startTime;
+    this.log = [];
+  }
+
+  // Record band values for the current frame
+  logFrame(bands, time = performance.now()) {
+    if (this.log.length >= this.maxEntries) return;
+    const timestamp = Math.round(time - this.startTime);
+    const rounded = bands.map(v => Number(v.toFixed(2)));
+    this.log.push({ timestamp, bands: rounded });
+  }
+
+  // Retrieve the full log
+  getLog() {
+    return this.log;
+  }
+
+  // Download the log as a JSON file
+  download() {
+    const pad = n => String(n).padStart(2, '0');
+    const d = new Date();
+    const name = `visual_cue_${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}_${pad(d.getHours())}-${pad(d.getMinutes())}-${pad(d.getSeconds())}.json`;
+    const blob = new Blob([JSON.stringify(this.log)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = name;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,7 @@ window.addEventListener('DOMContentLoaded', () => {
     fileInput: document.getElementById('fileInput'),
     playBtn: document.getElementById('playBtn'),
     stopBtn: document.getElementById('stopBtn'),
+    downloadBtn: document.getElementById('downloadCue'),
     canvas: document.getElementById('canvas'),
     settingsPanel: document.getElementById('settingsPanel'),
   };

--- a/src/render/VisualizerCanvas.js
+++ b/src/render/VisualizerCanvas.js
@@ -7,21 +7,17 @@ export default class VisualizerCanvas {
     this.numBars = numBars;
     this.animationId = null;
     this.prev = new Array(numBars).fill(0);
-    this.prevBeat = false;
   }
 
-  drawFrame(buckets, settings) {
+  drawFrame(buckets, settings, beat = false) {
     const width = this.canvas.clientWidth;
     const height = this.canvas.clientHeight;
     this.canvas.width = width;
     this.canvas.height = height;
     const { colorMode, intensity, smoothing, strobe } = settings;
 
-    const beat = buckets[0] > 0.8 && !this.prevBeat;
-    this.prevBeat = buckets[0] > 0.8;
-
     if (strobe && beat) {
-      this.ctx.fillStyle = 'white';
+      this.ctx.fillStyle = 'rgba(255,255,255,0.8)';
       this.ctx.fillRect(0, 0, width, height);
       return;
     }
@@ -46,9 +42,11 @@ export default class VisualizerCanvas {
     }
   }
 
-  start(drawFn, settings) {
+  start(drawFn, settings, onFrame) {
     const loop = () => {
-      this.drawFrame(drawFn(), settings);
+      const buckets = drawFn();
+      const beat = onFrame ? onFrame(buckets) : false;
+      this.drawFrame(buckets, settings, beat);
       this.animationId = requestAnimationFrame(loop);
     };
     loop();

--- a/src/ui/Controls.js
+++ b/src/ui/Controls.js
@@ -1,8 +1,9 @@
 export default class Controls {
-  constructor(fileInput, playBtn, stopBtn) {
+  constructor(fileInput, playBtn, stopBtn, downloadBtn) {
     this.fileInput = fileInput;
     this.playBtn = playBtn;
     this.stopBtn = stopBtn;
+    this.downloadBtn = downloadBtn;
   }
 
   bindLoad(handler) {
@@ -20,8 +21,17 @@ export default class Controls {
     this.stopBtn.addEventListener('click', handler);
   }
 
+  bindDownload(handler) {
+    this.downloadBtn.addEventListener('click', handler);
+  }
+
   enable() {
     this.playBtn.disabled = false;
     this.stopBtn.disabled = false;
+    this.downloadBtn.disabled = false;
+  }
+
+  setDownloadEnabled(enabled) {
+    this.downloadBtn.disabled = !enabled;
   }
 }

--- a/src/ui/SettingsPanel.js
+++ b/src/ui/SettingsPanel.js
@@ -10,7 +10,7 @@ export default class SettingsPanel {
     this.colorMode = this.container.querySelector('#colorMode');
     this.intensity = this.container.querySelector('#intensity');
     this.smoothing = this.container.querySelector('#smoothing');
-    this.strobe = this.container.querySelector('#strobe');
+    this.strobe = this.container.querySelector('#strobeToggle');
 
     const update = () => {
       this.settings.colorMode = this.colorMode.value;

--- a/tests/audio/BeatDetector.test.js
+++ b/tests/audio/BeatDetector.test.js
@@ -1,0 +1,16 @@
+import BeatDetector from '../../src/audio/BeatDetector.js';
+
+describe('BeatDetector', () => {
+  test('detects rising energy as a beat', () => {
+    const detector = new BeatDetector(0);
+    // Fill history with low energy
+    for (let i = 0; i < 60; i++) {
+      detector.update([0.1, 0.1], i * 16);
+    }
+    const beat = detector.update([1, 1], 1000);
+    expect(beat).toBe(true);
+    // Immediately following frame should not trigger due to cooldown 0? Actually 0 -> not; but we set 0 to disable so we expect true again when energy still high
+    const next = detector.update([0.1, 0.1], 1010);
+    expect(next).toBe(false);
+  });
+});

--- a/tests/core/CueLogger.test.js
+++ b/tests/core/CueLogger.test.js
@@ -1,0 +1,13 @@
+import CueLogger from '../../src/core/CueLogger.js';
+
+describe('CueLogger', () => {
+  test('records rounded band data with timestamps', () => {
+    const logger = new CueLogger(5);
+    logger.reset(0);
+    logger.logFrame([0.1234, 0.5678], 50);
+    logger.logFrame([0.9, 0.1], 100);
+    const log = logger.getLog();
+    expect(log.length).toBe(2);
+    expect(log[0]).toEqual({ timestamp: 50, bands: [0.12, 0.57] });
+  });
+});

--- a/tests/render/VisualizerCanvas.test.js
+++ b/tests/render/VisualizerCanvas.test.js
@@ -9,6 +9,6 @@ describe('VisualizerCanvas', () => {
     const canvas = document.getElementById('c');
     const vis = new VisualizerCanvas(canvas, 2);
     const settings = { colorMode: 'Rainbow', intensity: 1, smoothing: 0.2, strobe: false };
-    expect(() => vis.drawFrame([0.5, 1], settings)).not.toThrow();
+    expect(() => vis.drawFrame([0.5, 1], settings, false)).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- add `CueLogger` for recording band data per frame
- implement simple `BeatDetector` with energy history
- extend `VisualizerCanvas` to support beat-driven flashes
- integrate logging and beat detection in `AppController`
- update controls and settings panel for new UI elements
- provide new tests for the added modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68488e3ad2f4833087859400e25dc204