### PR TITLE
Add tunnel scene and scene selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,10 @@
     <button id="stopBtn" disabled>Stop</button>
     <button id="downloadCue" disabled>Download Cue JSON</button>
   </div>
+  <div id="sceneButtons">
+    <button data-scene="bars">Bars</button>
+    <button data-scene="tunnel">Tunnel</button>
+  </div>
   <div id="settingsPanel">
     <label>Color Mode
       <select id="colorMode">

--- a/src/core/AppController.js
+++ b/src/core/AppController.js
@@ -7,11 +7,12 @@ import SceneConfig from '../render/SceneConfig.js';
 import Controls from '../ui/Controls.js';
 import SettingsPanel from '../ui/SettingsPanel.js';
 import FpsCounter from '../ui/FpsCounter.js';
+import SceneButtons from '../ui/SceneButtons.js';
 import CueLogger from './CueLogger.js';
 
 export default class AppController {
   constructor(elements) {
-    const { fileInput, playBtn, stopBtn, downloadBtn, canvas, settingsPanel, fpsDisplay } = elements;
+    const { fileInput, playBtn, stopBtn, downloadBtn, canvas, settingsPanel, fpsDisplay, sceneButtons } = elements;
     this.controls = new Controls(fileInput, playBtn, stopBtn, downloadBtn);
     this.settings = {
       colorMode: 'Rainbow',
@@ -25,6 +26,7 @@ export default class AppController {
     this.analyzer = new AudioAnalyzer(this.player.audioCtx, SceneConfig.NUM_BARS);
     this.visualizer = new VisualizerCanvas(canvas, SceneConfig.NUM_BARS);
     this.fpsCounter = new FpsCounter(fpsDisplay);
+    this.sceneButtons = new SceneButtons(sceneButtons);
     this.cueLogger = new CueLogger();
     this.beatDetector = new BeatDetector();
     this.animationId = null;
@@ -72,6 +74,10 @@ export default class AppController {
     });
     this.controls.bindDownload(() => {
       this.cueLogger.download();
+    });
+
+    this.sceneButtons.bindSceneChange(scene => {
+      this.visualizer.setScene(scene);
     });
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -9,6 +9,7 @@ window.addEventListener('DOMContentLoaded', () => {
     canvas: document.getElementById('canvas'),
     settingsPanel: document.getElementById('settingsPanel'),
     fpsDisplay: document.getElementById('fpsDisplay'),
+    sceneButtons: document.getElementById('sceneButtons'),
   };
   new AppController(elements);
 });

--- a/src/ui/SceneButtons.js
+++ b/src/ui/SceneButtons.js
@@ -1,0 +1,18 @@
+export default class SceneButtons {
+  constructor(container) {
+    this.container = container;
+  }
+
+  /**
+   * Register handler for scene button clicks.
+   * @param {(scene:string) => void} handler - callback with chosen scene
+   */
+  bindSceneChange(handler) {
+    this.container.addEventListener('click', e => {
+      const scene = e.target.dataset.scene;
+      if (scene) {
+        handler(scene);
+      }
+    });
+  }
+}

--- a/style.css
+++ b/style.css
@@ -14,6 +14,12 @@ body {
   margin-top: 20px;
 }
 
+#sceneButtons {
+  margin-top: 10px;
+  display: flex;
+  gap: 6px;
+}
+
 #settingsPanel {
   display: flex;
   flex-direction: column;

--- a/tests/render/VisualizerCanvas.test.js
+++ b/tests/render/VisualizerCanvas.test.js
@@ -11,4 +11,12 @@ describe('VisualizerCanvas', () => {
     const settings = { colorMode: 'Rainbow', intensity: 1, smoothing: 0.2, strobe: false };
     expect(() => vis.drawFrame([0.5, 1], settings, false)).not.toThrow();
   });
+
+  test('tunnel scene draws without errors', () => {
+    const canvas = document.getElementById('c');
+    const vis = new VisualizerCanvas(canvas, 2);
+    const settings = { colorMode: 'Rainbow', intensity: 1, smoothing: 0.2, strobe: false };
+    vis.setScene('tunnel');
+    expect(() => vis.drawFrame([0.5, 1], settings, false)).not.toThrow();
+  });
 });

--- a/tests/ui/SceneButtons.test.js
+++ b/tests/ui/SceneButtons.test.js
@@ -1,0 +1,13 @@
+import SceneButtons from '../../src/ui/SceneButtons.js';
+
+describe('SceneButtons', () => {
+  test('bindSceneChange fires handler with dataset', () => {
+    document.body.innerHTML = '<div id="sc"><button data-scene="bars"></button></div>';
+    const container = document.getElementById('sc');
+    const buttons = new SceneButtons(container);
+    const handler = jest.fn();
+    buttons.bindSceneChange(handler);
+    container.querySelector('button').click();
+    expect(handler).toHaveBeenCalledWith('bars');
+  });
+});


### PR DESCRIPTION
## Summary
- introduce scene switch buttons in UI
- create SceneButtons UI helper
- allow changing scenes in AppController
- expand VisualizerCanvas with tunnel scene
- style and test updates

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849cc29d93c83309d19e79b438f7b81