### PR TITLE
Implement Three.js renderer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,8 @@ This project is an audio-reactive visualizer built with JavaScript, Web Audio AP
     - `AudioPlayer.js` — manages load/play/pause of audio
     - `AudioAnalyzer.js` — real-time FFT & frequency data interface
   - `/render/` — rendering logic
-    - `VisualizerCanvas.js` — draws visuals based on mapped data
+    - `VisualizerThree.js` — Three.js based visualizer
+    - `VisualizerCanvas.js` — legacy 2-D fallback
     - `SceneConfig.js` — defines visual fixture layout & mappings
   - `/core/` — controller logic
     - `AppController.js` — coordinates audio/render/UI components
@@ -35,7 +36,7 @@ This project is an audio-reactive visualizer built with JavaScript, Web Audio AP
 - Code should be **modular** and avoid large monolithic files
 - Prefer **dependency injection** for config/state
 - Naming conventions:
-  - PascalCase for classes and components (`VisualizerCanvas`)
+  - PascalCase for classes and components (`VisualizerThree`)
   - camelCase for functions and variables (`mapFftToVisuals`)
 - Each function or method must include a short comment for non-obvious logic
 - Files should be ≤ 200 LOC if possible
@@ -72,3 +73,7 @@ npm test -- --watch   # watch mode for development
 **Common Issue**: If you see "sh: 1: jest: not found", it means you're trying to run `jest` directly instead of through npm scripts. Jest is not globally installed (which is correct for this project).
 
 **Dependencies**: Make sure `npm install` has been run to install all dev dependencies including jest.
+
+### Three.js Integration
+
+The 3D bars scene uses `three` via `VisualizerThree.js`. The tunnel scene is currently a placeholder. Install dependencies with `npm install` to ensure `three` is available.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Clone and run:
 git clone <repo-url> && cd AudioViz2 && npm i && npm run dev
 ```
 
+The bars visualization now uses **Three.js** for 3D rendering. Running `npm install` installs the required `three` dependency.
+
 ## Project Structure
 
 ```
@@ -31,3 +33,5 @@ Run the test suite with:
 npm test
 npx jest --coverage
 ```
+
+The tunnel scene is currently disabled when using the Three.js renderer.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
       "name": "audioviz2",
       "version": "1.0.0",
       "license": "ISC",
+      "dependencies": {
+        "three": "^0.160.0"
+      },
       "devDependencies": {
         "@babel/core": "^7.27.4",
         "@babel/preset-env": "^7.27.2",
@@ -8618,6 +8621,12 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/three": {
+      "version": "0.160.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.160.1.tgz",
+      "integrity": "sha512-Bgl2wPJypDOZ1stAxwfWAcJ0WQf7QzlptsxkjYiURPz+n5k4RBDLsq+6f9Y75TYxn6aHLcWz+JNmwTOXWrQTBQ==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.14",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "author": "",
   "license": "ISC",
   "type": "module",
+  "dependencies": {
+    "three": "^0.160.0"
+  },
   "devDependencies": {
     "@babel/core": "^7.27.4",
     "@babel/preset-env": "^7.27.2",

--- a/src/core/AppController.js
+++ b/src/core/AppController.js
@@ -2,7 +2,7 @@ import AudioPlayer from '../audio/AudioPlayer.js';
 import AudioAnalyzer from '../audio/AudioAnalyzer.js';
 import BeatDetector from '../audio/BeatDetector.js';
 import mapSensitivityToThreshold from '../audio/mapSensitivityToThreshold.js';
-import VisualizerCanvas from '../render/VisualizerCanvas.js';
+import VisualizerThree from '../render/VisualizerThree.js';
 import SceneConfig from '../render/SceneConfig.js';
 import Controls from '../ui/Controls.js';
 import SettingsPanel from '../ui/SettingsPanel.js';
@@ -24,7 +24,7 @@ export default class AppController {
     new SettingsPanel(settingsPanel, this.settings);
     this.player = new AudioPlayer();
     this.analyzer = new AudioAnalyzer(this.player.audioCtx, SceneConfig.NUM_BARS);
-    this.visualizer = new VisualizerCanvas(canvas, SceneConfig.NUM_BARS);
+    this.visualizer = new VisualizerThree(canvas, SceneConfig.NUM_BARS);
     this.fpsCounter = new FpsCounter(fpsDisplay);
     this.sceneButtons = new SceneButtons(sceneButtons);
     this.cueLogger = new CueLogger();

--- a/src/render/VisualizerThree.js
+++ b/src/render/VisualizerThree.js
@@ -1,0 +1,112 @@
+import * as THREE from 'three';
+import applySmoothing from './applySmoothing.js';
+
+/**
+ * Three.js based visualizer with a bars scene.
+ * The tunnel scene is currently a no-op placeholder.
+ */
+export default class VisualizerThree {
+  constructor(canvas, numBars) {
+    this.canvas = canvas;
+    this.numBars = numBars;
+    this.renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+    this.scene = new THREE.Scene();
+    this.camera = new THREE.PerspectiveCamera(
+      70,
+      canvas.clientWidth / canvas.clientHeight,
+      0.1,
+      1000
+    );
+    this.camera.position.z = 5;
+    this.bars = [];
+    this.prev = new Array(numBars).fill(0);
+    this.activeScene = 'bars';
+    this.initBars();
+  }
+
+  /** Initialize bar meshes and add them to the scene */
+  initBars() {
+    const spacing = 1.2;
+    for (let i = 0; i < this.numBars; i++) {
+      const geometry = new THREE.BoxGeometry(1, 1, 1);
+      const material = new THREE.MeshBasicMaterial({ color: 0xffffff });
+      const mesh = new THREE.Mesh(geometry, material);
+      mesh.position.x = (i - this.numBars / 2) * spacing;
+      this.scene.add(mesh);
+      this.bars.push(mesh);
+    }
+  }
+
+  /** Map bar index and settings to a display color */
+  getColor(index, colorMode, buckets) {
+    if (colorMode === 'Rainbow') {
+      const hue = (index / this.numBars) * 360;
+      return new THREE.Color(`hsl(${hue}, 100%, 50%)`);
+    }
+    if (colorMode === 'Bass') {
+      const hue = buckets[0] * 200;
+      return new THREE.Color(`hsl(${hue}, 100%, 50%)`);
+    }
+    return new THREE.Color('#ffffff');
+  }
+
+  /** Set the active scene */
+  setScene(scene) {
+    this.activeScene = scene;
+    this.prev.fill(0);
+  }
+
+  resize() {
+    const width = this.canvas.clientWidth;
+    const height = this.canvas.clientHeight;
+    this.renderer.setSize(width, height, false);
+    this.camera.aspect = width / height;
+    if (this.camera.updateProjectionMatrix) {
+      this.camera.updateProjectionMatrix();
+    }
+  }
+
+  drawBars(buckets, settings) {
+    this.resize();
+    const { colorMode, intensity, smoothing } = settings;
+    for (let i = 0; i < this.numBars; i++) {
+      const current = Math.min(buckets[i] * intensity, 1);
+      const height = applySmoothing(this.prev[i], current, smoothing) * 4 + 0.1;
+      this.prev[i] = height / 4;
+      const bar = this.bars[i];
+      bar.scale.y = height;
+      bar.position.y = height / 2 - 0.5;
+      bar.material.color = this.getColor(i, colorMode, buckets);
+    }
+    this.renderer.render(this.scene, this.camera);
+  }
+
+  drawTunnel() {
+    this.resize();
+    this.renderer.render(this.scene, this.camera);
+  }
+
+  drawFrame(buckets, settings, beat = false) {
+    if (this.activeScene === 'tunnel') {
+      this.drawTunnel(buckets, settings, beat);
+    } else {
+      this.drawBars(buckets, settings, beat);
+    }
+  }
+
+  start(drawFn, settings, fpsCounter = null, onFrame = null) {
+    const loop = () => {
+      if (fpsCounter) fpsCounter.tick();
+      const buckets = drawFn();
+      const beat = onFrame ? onFrame(buckets) : false;
+      this.drawFrame(buckets, settings, beat);
+      this.animationId = requestAnimationFrame(loop);
+    };
+    loop();
+  }
+
+  stop() {
+    cancelAnimationFrame(this.animationId);
+    this.animationId = null;
+  }
+}

--- a/tests/render/VisualizerThree.test.js
+++ b/tests/render/VisualizerThree.test.js
@@ -1,0 +1,47 @@
+jest.mock('three', () => {
+  const mockRender = jest.fn();
+  const mockAdd = jest.fn();
+  return {
+    WebGLRenderer: jest.fn(() => ({
+      setSize: jest.fn(),
+      render: mockRender,
+    })),
+    Scene: jest.fn(() => ({ add: mockAdd })),
+    PerspectiveCamera: jest.fn(() => ({
+      position: { z: 0 },
+      updateProjectionMatrix: jest.fn(),
+    })),
+    BoxGeometry: jest.fn(),
+    MeshBasicMaterial: jest.fn(() => ({ color: {} })),
+    Mesh: jest.fn(() => ({
+      scale: { y: 1 },
+      position: { x: 0, y: 0 },
+      material: { color: {} },
+    })),
+    Color: jest.fn(() => ({})),
+  };
+});
+
+import VisualizerThree from '../../src/render/VisualizerThree.js';
+
+describe('VisualizerThree', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<canvas id="c" width="300" height="150"></canvas>';
+  });
+
+  test('drawFrame runs without errors', () => {
+    const canvas = document.getElementById('c');
+    const vis = new VisualizerThree(canvas, 2);
+    const settings = { colorMode: 'Rainbow', intensity: 1, smoothing: 0.2, strobe: false };
+    expect(() => vis.drawFrame([0.5, 1], settings, false)).not.toThrow();
+  });
+
+  test('tunnel scene does not throw', () => {
+    const canvas = document.getElementById('c');
+    const vis = new VisualizerThree(canvas, 2);
+    const settings = { colorMode: 'Rainbow', intensity: 1, smoothing: 0.2, strobe: false };
+    vis.setScene('tunnel');
+    expect(() => vis.drawFrame([0.5, 1], settings, false)).not.toThrow();
+  });
+});
+


### PR DESCRIPTION
## Summary
- add three as a dependency
- create `VisualizerThree` for WebGL rendering
- use `VisualizerThree` in `AppController`
- document Three.js usage in README and AGENTS
- add unit tests for `VisualizerThree`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849cf4d84408330a02fc42c452fa396