### PR TITLE
Add simple hexagon tunnel scene

### DIFF
--- a/src/render/VisualizerThree.js
+++ b/src/render/VisualizerThree.js
@@ -50,9 +50,11 @@ export default class VisualizerThree {
 
   /** Initialize tunnel ring meshes */
   initTunnel() {
+    const inner = 2.8; // inner radius for hexagon ring
+    const outer = 3; // outer radius for hexagon ring
     for (let i = 0; i < this.tunnelSegments; i++) {
-      const geometry = new THREE.TorusGeometry(3, 0.1, 8, 16);
-      const material = new THREE.MeshBasicMaterial({ color: 0xffffff });
+      const geometry = new THREE.RingGeometry(inner, outer, 6);
+      const material = new THREE.MeshBasicMaterial({ color: 0x00ffff, side: THREE.DoubleSide });
       const mesh = new THREE.Mesh(geometry, material);
       mesh.rotation.x = Math.PI / 2;
       mesh.position.z = -i * this.tunnelSpacing;
@@ -130,17 +132,8 @@ export default class VisualizerThree {
     this.resize();
     const energy = buckets.reduce((s, v) => s + v, 0) / buckets.length;
     const scale = 1 + energy * settings.intensity;
-    this.hueOffset = (this.hueOffset + 0.5) % 360;
-    const loopDist = this.tunnelSegments * this.tunnelSpacing;
-    for (let i = 0; i < this.tunnelRings.length; i++) {
-      const ring = this.tunnelRings[i];
-      ring.position.z += this.tunnelSpeed;
-      if (ring.position.z > this.camera.position.z) {
-        ring.position.z -= loopDist;
-      }
+    for (const ring of this.tunnelRings) {
       ring.scale.setScalar(scale);
-      const hue = (this.hueOffset + (i / this.tunnelRings.length) * 360) % 360;
-      ring.material.color = new THREE.Color(`hsl(${hue}, 100%, 50%)`);
     }
     this.renderer.render(this.scene, this.camera);
   }

--- a/tests/render/VisualizerThree.test.js
+++ b/tests/render/VisualizerThree.test.js
@@ -13,6 +13,7 @@ jest.mock('three', () => {
     })),
     BoxGeometry: jest.fn(),
     TorusGeometry: jest.fn(),
+    RingGeometry: jest.fn(),
     MeshBasicMaterial: jest.fn(() => ({ color: {} })),
     Mesh: jest.fn(() => ({
       scale: { y: 1, setScalar: jest.fn() },
@@ -20,6 +21,7 @@ jest.mock('three', () => {
       rotation: { x: 0 },
       material: { color: {} },
     })),
+    DoubleSide: 2,
     Color: jest.fn(() => ({})),
     MeshPhongMaterial: jest.fn(() => ({})),
   };


### PR DESCRIPTION
## Summary
- simplify the 3D tunnel scene by replacing torus rings with static-color hexagon rings
- adjust animation so rings bounce based on audio energy
- update three.js mocks in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849d65710e48330b495d2638d57c23b