### PR TITLE
Add editable 3D text scene settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ npx jest --coverage
 ```
 
 The tunnel scene is currently disabled when using the Three.js renderer. A new
-**3D text** scene displays rotating text that gently bounces to the beat.
+**3D text** scene displays rotating text that gently bounces to the beat. When this scene is active a text field appears in the settings panel allowing the displayed text to be edited in real time.

--- a/index.html
+++ b/index.html
@@ -38,6 +38,9 @@
     <label id="strobeSensitivityLabel">Strobe Sensitivity
       <input type="range" id="strobeSensitivity" min="0" max="100" step="1" value="50" />
     </label>
+    <label id="textContentLabel">Text
+      <input type="text" id="textContent" value="AudioViz" />
+    </label>
   </div>
   <div id="fpsDisplay">FPS: 0</div>
   <canvas id="canvas"></canvas>

--- a/src/core/AppController.js
+++ b/src/core/AppController.js
@@ -22,11 +22,12 @@ export default class AppController {
       smoothing: 0.2,
       strobe: false,
       strobeSensitivity: 50,
+      textContent: 'AudioViz',
     };
-    new SettingsPanel(settingsPanel, this.settings);
+    this.settingsPanel = new SettingsPanel(settingsPanel, this.settings);
     this.player = new AudioPlayer();
     this.analyzer = new AudioAnalyzer(this.player.audioCtx, SceneConfig.NUM_BARS);
-    this.threeLayer = new ThreeJsLayer(canvas, SceneConfig.NUM_BARS);
+    this.threeLayer = new ThreeJsLayer(canvas, SceneConfig.NUM_BARS, this.settings.textContent);
     this.strobeLayer = new StrobeLayer(overlay);
     this.layerManager = new LayerManager([this.threeLayer, this.strobeLayer]);
     this.fpsCounter = new FpsCounter(fpsDisplay);
@@ -82,6 +83,14 @@ export default class AppController {
 
     this.sceneButtons.bindSceneChange(scene => {
       this.threeLayer.visualizer.setScene(scene);
+      this.settingsPanel.toggleTextInput(scene === 'text');
+      if (scene === 'text') {
+        this.threeLayer.visualizer.setText(this.settings.textContent);
+      }
+    });
+
+    this.settingsPanel.bindTextChange(text => {
+      this.threeLayer.visualizer.setText(text);
     });
   }
 }

--- a/src/render/VisualizerThree.js
+++ b/src/render/VisualizerThree.js
@@ -8,7 +8,7 @@ import applySmoothing from './applySmoothing.js';
  * The tunnel scene renders a moving 3D pipeline that reacts to music.
  */
 export default class VisualizerThree {
-  constructor(canvas, numBars) {
+  constructor(canvas, numBars, text = 'AudioViz') {
     this.canvas = canvas;
     this.numBars = numBars;
     this.renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
@@ -31,8 +31,10 @@ export default class VisualizerThree {
     this.initBars();
     this.initTunnel();
     this.textMesh = null;
+    this.font = null;
+    this.pendingText = text;
     this.initBars();
-    this.initText();
+    this.initText(text);
   }
 
   /** Initialize bar meshes and add them to the scene */
@@ -62,11 +64,21 @@ export default class VisualizerThree {
   }
 
   /** Load font and create 3D text mesh */
-  initText() {
+  initText(text) {
     const loader = new FontLoader();
     loader.load('/fonts/helvetiker_regular.typeface.json', font => {
-      const geometry = new TextGeometry('AudioViz', {
-        font,
+      this.font = font;
+      this.setText(text || this.pendingText);
+      this.pendingText = null;
+    });
+  }
+
+  /** Update the displayed 3D text */
+  setText(text) {
+    if (this.font) {
+      if (this.textMesh) this.scene.remove(this.textMesh);
+      const geometry = new TextGeometry(text, {
+        font: this.font,
         size: 1,
         height: 0.2,
       });
@@ -74,7 +86,9 @@ export default class VisualizerThree {
       const material = new THREE.MeshPhongMaterial({ color: 0xffffff });
       this.textMesh = new THREE.Mesh(geometry, material);
       this.scene.add(this.textMesh);
-    });
+    } else {
+      this.pendingText = text;
+    }
   }
 
   /** Map bar index and settings to a display color */

--- a/src/render/layers/ThreeJsLayer.js
+++ b/src/render/layers/ThreeJsLayer.js
@@ -2,9 +2,9 @@ import Layer from './Layer.js';
 import VisualizerThree from '../VisualizerThree.js';
 
 export default class ThreeJsLayer extends Layer {
-  constructor(canvas, numBars) {
+  constructor(canvas, numBars, text = 'AudioViz') {
     super();
-    this.visualizer = new VisualizerThree(canvas, numBars);
+    this.visualizer = new VisualizerThree(canvas, numBars, text);
   }
 
   render(data, settings) {

--- a/src/ui/SettingsPanel.js
+++ b/src/ui/SettingsPanel.js
@@ -2,6 +2,7 @@ export default class SettingsPanel {
   constructor(container, settings) {
     this.settings = settings;
     this.container = container;
+    this.onTextChange = null;
     this.init();
   }
 
@@ -13,6 +14,8 @@ export default class SettingsPanel {
     this.strobe = this.container.querySelector('#strobeToggle');
     this.strobeSensitivity = this.container.querySelector('#strobeSensitivity');
     this.strobeSensLabel = this.container.querySelector('#strobeSensitivityLabel');
+    this.textInput = this.container.querySelector('#textContent');
+    this.textLabel = this.container.querySelector('#textContentLabel');
 
     const update = () => {
       this.settings.colorMode = this.colorMode.value;
@@ -20,6 +23,9 @@ export default class SettingsPanel {
       this.settings.smoothing = parseFloat(this.smoothing.value);
       this.settings.strobe = this.strobe.checked;
       this.settings.strobeSensitivity = parseFloat(this.strobeSensitivity.value);
+      if (this.textInput) {
+        this.settings.textContent = this.textInput.value;
+      }
     };
 
     ['change', 'input'].forEach(evt => {
@@ -27,6 +33,12 @@ export default class SettingsPanel {
       this.intensity.addEventListener(evt, update);
       this.smoothing.addEventListener(evt, update);
       this.strobeSensitivity.addEventListener(evt, update);
+      if (this.textInput) {
+        this.textInput.addEventListener(evt, e => {
+          update();
+          if (this.onTextChange) this.onTextChange(e.target.value);
+        });
+      }
     });
     this.strobe.addEventListener('change', e => {
       update();
@@ -36,5 +48,20 @@ export default class SettingsPanel {
 
     update();
     this.strobeSensLabel.style.display = this.strobe.checked ? 'flex' : 'none';
+    if (this.textLabel) {
+      this.textLabel.style.display = 'none';
+    }
+  }
+
+  /** Show or hide the text input for the 3D text scene */
+  toggleTextInput(show) {
+    if (this.textLabel) {
+      this.textLabel.style.display = show ? 'flex' : 'none';
+    }
+  }
+
+  /** Bind callback for when text content changes */
+  bindTextChange(handler) {
+    this.onTextChange = handler;
   }
 }

--- a/tests/ui/SettingsPanel.test.js
+++ b/tests/ui/SettingsPanel.test.js
@@ -1,0 +1,28 @@
+import SettingsPanel from '../../src/ui/SettingsPanel.js';
+
+describe('SettingsPanel', () => {
+  test('bindTextChange triggers handler', () => {
+    document.body.innerHTML = '<div id="sp"><input id="colorMode"/><input id="intensity"/><input id="smoothing"/><input id="strobeToggle" type="checkbox"/><input id="strobeSensitivity"/><label id="strobeSensitivityLabel"></label><label id="textContentLabel"><input id="textContent"/></label></div>';
+    const container = document.getElementById('sp');
+    const settings = {};
+    const panel = new SettingsPanel(container, settings);
+    const handler = jest.fn();
+    panel.bindTextChange(handler);
+    const input = container.querySelector('#textContent');
+    input.value = 'Hello';
+    input.dispatchEvent(new Event('input'));
+    expect(handler).toHaveBeenCalledWith('Hello');
+  });
+
+  test('toggleTextInput shows and hides label', () => {
+    document.body.innerHTML = '<div id="sp"><label id="textContentLabel" style="display:none"><input id="textContent"/></label><input id="colorMode"/><input id="intensity"/><input id="smoothing"/><input id="strobeToggle"/><input id="strobeSensitivity"/><label id="strobeSensitivityLabel"></label></div>';
+    const container = document.getElementById('sp');
+    const settings = {};
+    const panel = new SettingsPanel(container, settings);
+    const label = container.querySelector('#textContentLabel');
+    panel.toggleTextInput(true);
+    expect(label.style.display).toBe('flex');
+    panel.toggleTextInput(false);
+    expect(label.style.display).toBe('none');
+  });
+});


### PR DESCRIPTION
## Summary
- allow changing displayed text in 3D text scene
- hide/show text input when switching scenes
- wire AppController to update VisualizerThree text
- test SettingsPanel behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849d681054083308c8cf1d3d3bd7199