### PR TITLE
Add gradient library and integrate into bar visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,16 @@
         <option value="Rainbow">Rainbow</option>
         <option value="Bass">Bass-colored</option>
         <option value="White">Fixed White</option>
+        <option value="Sunset">Sunset</option>
+        <option value="Ocean">Ocean</option>
+        <option value="Forest">Forest</option>
+        <option value="Fire">Fire</option>
+        <option value="Sky">Sky</option>
+        <option value="Candy">Candy</option>
+        <option value="Heatmap">Heatmap</option>
+        <option value="Pastel">Pastel</option>
+        <option value="Neon">Neon</option>
+        <option value="Aurora">Aurora</option>
       </select>
     </label>
     <label>Intensity

--- a/src/render/VisualizerCanvas.js
+++ b/src/render/VisualizerCanvas.js
@@ -1,4 +1,5 @@
 import applySmoothing from './applySmoothing.js';
+import { gradients, colorAt } from './gradients.js';
 
 
 export default class VisualizerCanvas {
@@ -26,6 +27,10 @@ export default class VisualizerCanvas {
     if (colorMode === 'Bass') {
       const hue = buckets[0] * 200;
       return `hsl(${hue}, 100%, 50%)`;
+    }
+    if (gradients[colorMode]) {
+      const t = index / this.numBars;
+      return colorAt(colorMode, t);
     }
     return '#fff';
   }

--- a/src/render/VisualizerThree.js
+++ b/src/render/VisualizerThree.js
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { FontLoader } from 'three/addons/loaders/FontLoader.js';
 import { TextGeometry } from 'three/addons/geometries/TextGeometry.js';
 import applySmoothing from './applySmoothing.js';
+import { gradients, colorAt } from './gradients.js';
 
 /**
  * Three.js based visualizer with both bar and tunnel scenes.
@@ -86,6 +87,10 @@ export default class VisualizerThree {
     if (colorMode === 'Bass') {
       const hue = buckets[0] * 200;
       return new THREE.Color(`hsl(${hue}, 100%, 50%)`);
+    }
+    if (gradients[colorMode]) {
+      const t = index / this.numBars;
+      return new THREE.Color(colorAt(colorMode, t));
     }
     return new THREE.Color('#ffffff');
   }

--- a/src/render/gradients.js
+++ b/src/render/gradients.js
@@ -1,0 +1,54 @@
+// Color gradient library accessible across the app
+// Each gradient is an array of hex color stops
+export const gradients = {
+  Sunset: ['#ff5e6c', '#ffc371'],
+  Ocean: ['#2193b0', '#6dd5ed'],
+  Forest: ['#5a3f37', '#2c7744'],
+  Fire: ['#f83600', '#f9d423'],
+  Sky: ['#2980b9', '#6dd5fa'],
+  Candy: ['#d3959b', '#bfe6ba'],
+  Heatmap: ['#ff9966', '#ff5e62'],
+  Pastel: ['#a1c4fd', '#c2e9fb'],
+  Neon: ['#00f260', '#0575e6'],
+  Aurora: ['#da4453', '#89216b'],
+};
+
+// Convert hex color to RGB object
+function hexToRgb(hex) {
+  const h = hex.replace('#', '');
+  const bigint = parseInt(h, 16);
+  return {
+    r: (bigint >> 16) & 255,
+    g: (bigint >> 8) & 255,
+    b: bigint & 255,
+  };
+}
+
+// Convert RGB object back to hex string
+function rgbToHex({ r, g, b }) {
+  const toHex = v => v.toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}
+
+/**
+ * Get interpolated color from gradient.
+ * @param {string} name - gradient name
+ * @param {number} t - value between 0 and 1
+ * @returns {string} hex color
+ */
+export function colorAt(name, t) {
+  const stops = gradients[name];
+  if (!stops) return '#ffffff';
+  const n = stops.length - 1;
+  const pos = Math.min(Math.max(t, 0), 1) * n;
+  const i = Math.floor(pos);
+  const frac = pos - i;
+  const c1 = hexToRgb(stops[i]);
+  const c2 = hexToRgb(stops[Math.min(i + 1, n)]);
+  const rgb = {
+    r: Math.round(c1.r + (c2.r - c1.r) * frac),
+    g: Math.round(c1.g + (c2.g - c1.g) * frac),
+    b: Math.round(c1.b + (c2.b - c1.b) * frac),
+  };
+  return rgbToHex(rgb);
+}

--- a/tests/render/gradients.test.js
+++ b/tests/render/gradients.test.js
@@ -1,0 +1,15 @@
+import { gradients, colorAt } from '../../src/render/gradients.js';
+
+describe('gradient library', () => {
+  test('contains at least 10 gradients', () => {
+    expect(Object.keys(gradients).length).toBeGreaterThanOrEqual(10);
+  });
+
+  test('colorAt interpolates first and last colors', () => {
+    const name = 'Sunset';
+    const first = colorAt(name, 0);
+    const last = colorAt(name, 1);
+    expect(first).toBe(gradients[name][0]);
+    expect(last).toBe(gradients[name][gradients[name].length - 1]);
+  });
+});


### PR DESCRIPTION
## Summary
- create `gradients.js` with 10 preset gradients and interpolation logic
- integrate gradients into `VisualizerCanvas` and `VisualizerThree`
- extend color mode options in `index.html`
- add unit tests for gradient library

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849d6f1a59c83308b6dd5a0f58f26fc