### PR TITLE
Add Perlin noise overlay layer

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,9 +38,29 @@
     <label id="strobeSensitivityLabel">Strobe Sensitivity
       <input type="range" id="strobeSensitivity" min="0" max="100" step="1" value="50" />
     </label>
+    <label>
+      <input type="checkbox" id="noiseToggle" /> Perlin Noise
+    </label>
+    <label>Noise Blend
+      <select id="noiseBlend">
+        <option value="overlay">Overlay</option>
+        <option value="screen">Screen</option>
+        <option value="multiply">Multiply</option>
+      </select>
+    </label>
+    <label>Noise Scale
+      <input type="range" id="noiseScale" min="20" max="200" step="10" value="80" />
+    </label>
+    <label>Noise Speed
+      <input type="range" id="noiseSpeed" min="0.001" max="0.05" step="0.001" value="0.01" />
+    </label>
+    <label>Noise Alpha
+      <input type="range" id="noiseAlpha" min="0" max="1" step="0.05" value="0.3" />
+    </label>
   </div>
   <div id="fpsDisplay">FPS: 0</div>
   <canvas id="canvas"></canvas>
+  <canvas id="noiseCanvas"></canvas>
   <canvas id="overlay"></canvas>
   <script type="module" src="/src/main.js"></script>
 </body>

--- a/src/core/AppController.js
+++ b/src/core/AppController.js
@@ -5,6 +5,7 @@ import mapSensitivityToThreshold from '../audio/mapSensitivityToThreshold.js';
 import LayerManager from '../render/layers/LayerManager.js';
 import ThreeJsLayer from '../render/layers/ThreeJsLayer.js';
 import StrobeLayer from '../render/layers/StrobeLayer.js';
+import PerlinNoiseLayer from '../render/layers/PerlinNoiseLayer.js';
 import SceneConfig from '../render/SceneConfig.js';
 import Controls from '../ui/Controls.js';
 import SettingsPanel from '../ui/SettingsPanel.js';
@@ -14,7 +15,7 @@ import CueLogger from './CueLogger.js';
 
 export default class AppController {
   constructor(elements) {
-    const { fileInput, playBtn, stopBtn, downloadBtn, canvas, overlay, settingsPanel, fpsDisplay, sceneButtons } = elements;
+    const { fileInput, playBtn, stopBtn, downloadBtn, canvas, overlay, noiseCanvas, settingsPanel, fpsDisplay, sceneButtons } = elements;
     this.controls = new Controls(fileInput, playBtn, stopBtn, downloadBtn);
     this.settings = {
       colorMode: 'Rainbow',
@@ -22,13 +23,25 @@ export default class AppController {
       smoothing: 0.2,
       strobe: false,
       strobeSensitivity: 50,
+      noise: {
+        enabled: false,
+        blend: 'overlay',
+        scale: 80,
+        speed: 0.01,
+        alpha: 0.3,
+      },
     };
     new SettingsPanel(settingsPanel, this.settings);
     this.player = new AudioPlayer();
     this.analyzer = new AudioAnalyzer(this.player.audioCtx, SceneConfig.NUM_BARS);
     this.threeLayer = new ThreeJsLayer(canvas, SceneConfig.NUM_BARS);
+    this.noiseLayer = new PerlinNoiseLayer(noiseCanvas);
     this.strobeLayer = new StrobeLayer(overlay);
-    this.layerManager = new LayerManager([this.threeLayer, this.strobeLayer]);
+    this.layerManager = new LayerManager([
+      this.threeLayer,
+      this.noiseLayer,
+      this.strobeLayer,
+    ]);
     this.fpsCounter = new FpsCounter(fpsDisplay);
     this.sceneButtons = new SceneButtons(sceneButtons);
     this.cueLogger = new CueLogger();

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@ window.addEventListener('DOMContentLoaded', () => {
     stopBtn: document.getElementById('stopBtn'),
     downloadBtn: document.getElementById('downloadCue'),
     canvas: document.getElementById('canvas'),
+    noiseCanvas: document.getElementById('noiseCanvas'),
     overlay: document.getElementById('overlay'),
     settingsPanel: document.getElementById('settingsPanel'),
     fpsDisplay: document.getElementById('fpsDisplay'),

--- a/src/render/layers/PerlinNoiseLayer.js
+++ b/src/render/layers/PerlinNoiseLayer.js
@@ -1,0 +1,109 @@
+import Layer from './Layer.js';
+
+// Simple Perlin noise generator
+class Perlin {
+  constructor() {
+    this.p = new Uint8Array(512);
+    for (let i = 0; i < 256; i++) this.p[i] = i;
+    for (let i = 0; i < 256; i++) {
+      const j = (Math.random() * 256) | 0;
+      [this.p[i], this.p[j]] = [this.p[j], this.p[i]];
+    }
+    for (let i = 0; i < 256; i++) this.p[i + 256] = this.p[i];
+  }
+  fade(t) {
+    return t * t * t * (t * (t * 6 - 15) + 10);
+  }
+  lerp(a, b, t) {
+    return a + t * (b - a);
+  }
+  grad(hash, x, y, z) {
+    const h = hash & 15;
+    const u = h < 8 ? x : y;
+    const v = h < 4 ? y : h === 12 || h === 14 ? x : z;
+    return ((h & 1) ? -u : u) + ((h & 2) ? -v : v);
+  }
+  noise(x, y, z) {
+    const X = Math.floor(x) & 255;
+    const Y = Math.floor(y) & 255;
+    const Z = Math.floor(z) & 255;
+    x -= Math.floor(x);
+    y -= Math.floor(y);
+    z -= Math.floor(z);
+    const u = this.fade(x);
+    const v = this.fade(y);
+    const w = this.fade(z);
+    const A = this.p[X] + Y;
+    const AA = this.p[A] + Z;
+    const AB = this.p[A + 1] + Z;
+    const B = this.p[X + 1] + Y;
+    const BA = this.p[B] + Z;
+    const BB = this.p[B + 1] + Z;
+    return this.lerp(
+      this.lerp(
+        this.lerp(this.grad(this.p[AA], x, y, z), this.grad(this.p[BA], x - 1, y, z), u),
+        this.lerp(this.grad(this.p[AB], x, y - 1, z), this.grad(this.p[BB], x - 1, y - 1, z), u),
+        v
+      ),
+      this.lerp(
+        this.lerp(
+          this.grad(this.p[AA + 1], x, y, z - 1),
+          this.grad(this.p[BA + 1], x - 1, y, z - 1),
+          u
+        ),
+        this.lerp(
+          this.grad(this.p[AB + 1], x, y - 1, z - 1),
+          this.grad(this.p[BB + 1], x - 1, y - 1, z - 1),
+          u
+        ),
+        v
+      ),
+      w
+    );
+  }
+}
+
+export default class PerlinNoiseLayer extends Layer {
+  constructor(canvas) {
+    super();
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d');
+    this.perlin = new Perlin();
+    this.time = 0;
+    this.imageData = null;
+  }
+
+  resize() {
+    const width = this.canvas.clientWidth || 1;
+    const height = this.canvas.clientHeight || 1;
+    this.canvas.width = width;
+    this.canvas.height = height;
+    this.imageData = this.ctx.createImageData(width, height);
+  }
+
+  // Draw animated perlin noise
+  render(_data, settings) {
+    this.resize();
+    const opts = settings.noise;
+    this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
+    if (!opts || !opts.enabled) return;
+    const { blend, scale, speed, alpha } = opts;
+    const { width, height } = this.canvas;
+    this.ctx.globalCompositeOperation = blend;
+    this.ctx.globalAlpha = alpha;
+    this.time += speed;
+    const img = this.imageData;
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const v = (this.perlin.noise(x / scale, y / scale, this.time) + 1) * 0.5;
+        const c = Math.floor(v * 255);
+        const idx = (y * width + x) * 4;
+        img.data[idx] = c;
+        img.data[idx + 1] = c;
+        img.data[idx + 2] = c;
+        img.data[idx + 3] = 255;
+      }
+    }
+    this.ctx.putImageData(img, 0, 0);
+  }
+}

--- a/src/ui/SettingsPanel.js
+++ b/src/ui/SettingsPanel.js
@@ -13,6 +13,11 @@ export default class SettingsPanel {
     this.strobe = this.container.querySelector('#strobeToggle');
     this.strobeSensitivity = this.container.querySelector('#strobeSensitivity');
     this.strobeSensLabel = this.container.querySelector('#strobeSensitivityLabel');
+    this.noise = this.container.querySelector('#noiseToggle');
+    this.noiseBlend = this.container.querySelector('#noiseBlend');
+    this.noiseScale = this.container.querySelector('#noiseScale');
+    this.noiseSpeed = this.container.querySelector('#noiseSpeed');
+    this.noiseAlpha = this.container.querySelector('#noiseAlpha');
 
     const update = () => {
       this.settings.colorMode = this.colorMode.value;
@@ -20,6 +25,11 @@ export default class SettingsPanel {
       this.settings.smoothing = parseFloat(this.smoothing.value);
       this.settings.strobe = this.strobe.checked;
       this.settings.strobeSensitivity = parseFloat(this.strobeSensitivity.value);
+      this.settings.noise.enabled = this.noise.checked;
+      this.settings.noise.blend = this.noiseBlend.value;
+      this.settings.noise.scale = parseFloat(this.noiseScale.value);
+      this.settings.noise.speed = parseFloat(this.noiseSpeed.value);
+      this.settings.noise.alpha = parseFloat(this.noiseAlpha.value);
     };
 
     ['change', 'input'].forEach(evt => {
@@ -27,12 +37,17 @@ export default class SettingsPanel {
       this.intensity.addEventListener(evt, update);
       this.smoothing.addEventListener(evt, update);
       this.strobeSensitivity.addEventListener(evt, update);
+      this.noiseBlend.addEventListener(evt, update);
+      this.noiseScale.addEventListener(evt, update);
+      this.noiseSpeed.addEventListener(evt, update);
+      this.noiseAlpha.addEventListener(evt, update);
     });
     this.strobe.addEventListener('change', e => {
       update();
       const show = e.target.checked;
       this.strobeSensLabel.style.display = show ? 'flex' : 'none';
     });
+    this.noise.addEventListener('change', update);
 
     update();
     this.strobeSensLabel.style.display = this.strobe.checked ? 'flex' : 'none';

--- a/style.css
+++ b/style.css
@@ -54,6 +54,17 @@ canvas {
   pointer-events: none;
 }
 
+#noiseCanvas {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: transparent;
+  z-index: 5;
+  pointer-events: none;
+}
+
 #fpsDisplay {
   position: absolute;
   top: 10px;

--- a/tests/render/layers/PerlinNoiseLayer.test.js
+++ b/tests/render/layers/PerlinNoiseLayer.test.js
@@ -1,0 +1,23 @@
+import PerlinNoiseLayer from '../../../src/render/layers/PerlinNoiseLayer.js';
+
+describe('PerlinNoiseLayer', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<canvas id="c" width="50" height="30"></canvas>';
+  });
+
+  test('draws noise when enabled', () => {
+    const canvas = document.getElementById('c');
+    const layer = new PerlinNoiseLayer(canvas);
+    const ctx = canvas.getContext('2d');
+    layer.render({}, { noise: { enabled: true, blend: 'overlay', scale: 50, speed: 0.01, alpha: 0.3 } });
+    expect(ctx.putImageData).toHaveBeenCalled();
+  });
+
+  test('skips drawing when disabled', () => {
+    const canvas = document.getElementById('c');
+    const layer = new PerlinNoiseLayer(canvas);
+    const ctx = canvas.getContext('2d');
+    layer.render({}, { noise: { enabled: false } });
+    expect(ctx.putImageData).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add PerlinNoiseLayer for animated noise overlay
- wire noise layer into AppController and SettingsPanel
- expand settings UI with noise controls and new canvas
- include CSS for noise canvas
- unit tests for PerlinNoiseLayer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849d6b90b308330b4a12439cdba6350