### PR TITLE
Add background color customization

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,6 +32,9 @@
     <label>Smoothing
       <input type="range" id="smoothing" min="0" max="1" step="0.05" value="0.2" />
     </label>
+    <label>Background
+      <input type="color" id="bgColor" value="#000000" />
+    </label>
     <label>
       <input type="checkbox" id="strobeToggle" /> Strobe on Beat
     </label>

--- a/src/core/AppController.js
+++ b/src/core/AppController.js
@@ -22,8 +22,9 @@ export default class AppController {
       smoothing: 0.2,
       strobe: false,
       strobeSensitivity: 50,
+      bgColor: '#000000',
     };
-    new SettingsPanel(settingsPanel, this.settings);
+    new SettingsPanel(settingsPanel, this.settings, canvas);
     this.player = new AudioPlayer();
     this.analyzer = new AudioAnalyzer(this.player.audioCtx, SceneConfig.NUM_BARS);
     this.threeLayer = new ThreeJsLayer(canvas, SceneConfig.NUM_BARS);

--- a/src/ui/SettingsPanel.js
+++ b/src/ui/SettingsPanel.js
@@ -1,7 +1,8 @@
 export default class SettingsPanel {
-  constructor(container, settings) {
+  constructor(container, settings, canvas) {
     this.settings = settings;
     this.container = container;
+    this.canvas = canvas;
     this.init();
   }
 
@@ -13,6 +14,7 @@ export default class SettingsPanel {
     this.strobe = this.container.querySelector('#strobeToggle');
     this.strobeSensitivity = this.container.querySelector('#strobeSensitivity');
     this.strobeSensLabel = this.container.querySelector('#strobeSensitivityLabel');
+    this.bgColor = this.container.querySelector('#bgColor');
 
     const update = () => {
       this.settings.colorMode = this.colorMode.value;
@@ -20,6 +22,10 @@ export default class SettingsPanel {
       this.settings.smoothing = parseFloat(this.smoothing.value);
       this.settings.strobe = this.strobe.checked;
       this.settings.strobeSensitivity = parseFloat(this.strobeSensitivity.value);
+      this.settings.bgColor = this.bgColor.value;
+      if (this.canvas) {
+        this.canvas.style.backgroundColor = this.bgColor.value;
+      }
     };
 
     ['change', 'input'].forEach(evt => {
@@ -27,6 +33,7 @@ export default class SettingsPanel {
       this.intensity.addEventListener(evt, update);
       this.smoothing.addEventListener(evt, update);
       this.strobeSensitivity.addEventListener(evt, update);
+      this.bgColor.addEventListener(evt, update);
     });
     this.strobe.addEventListener('change', e => {
       update();

--- a/style.css
+++ b/style.css
@@ -37,6 +37,13 @@ body {
   width: 120px;
 }
 
+#settingsPanel input[type='color'] {
+  width: 120px;
+  padding: 0;
+  border: none;
+  background: none;
+}
+
 canvas {
   flex: 1;
   width: 100%;

--- a/tests/ui/SettingsPanel.test.js
+++ b/tests/ui/SettingsPanel.test.js
@@ -1,0 +1,28 @@
+import SettingsPanel from '../../src/ui/SettingsPanel.js';
+
+describe('SettingsPanel', () => {
+  test('updates settings and canvas color', () => {
+    document.body.innerHTML = `
+      <div id="panel">
+        <input id="colorMode" value="Rainbow" />
+        <input id="intensity" value="1" />
+        <input id="smoothing" value="0.2" />
+        <input id="strobeToggle" type="checkbox" />
+        <input id="strobeSensitivity" value="50" />
+        <label id="strobeSensitivityLabel"></label>
+        <input id="bgColor" type="color" value="#ff0000" />
+      </div>
+      <canvas id="c"></canvas>`;
+    const panel = document.getElementById('panel');
+    const canvas = document.getElementById('c');
+    const settings = {};
+    new SettingsPanel(panel, settings, canvas);
+    expect(settings.bgColor).toBe('#ff0000');
+    expect(canvas.style.backgroundColor).toBe('rgb(255, 0, 0)');
+    const colorInput = panel.querySelector('#bgColor');
+    colorInput.value = '#00ff00';
+    colorInput.dispatchEvent(new Event('input'));
+    expect(settings.bgColor).toBe('#00ff00');
+    expect(canvas.style.backgroundColor).toBe('rgb(0, 255, 0)');
+  });
+});


### PR DESCRIPTION
## Summary
- add background color selector to UI
- apply color in SettingsPanel to canvas
- track bgColor in AppController settings
- style color input
- test SettingsPanel background color logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849d79291248330bdf3f2141b74b800