### PR TITLE
Add animated perlin noise layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,8 @@ npx jest --coverage
 
 The tunnel scene is currently disabled when using the Three.js renderer. A new
 **3D text** scene displays rotating text that gently bounces to the beat. When this scene is active a text field appears in the settings panel allowing the displayed text to be edited in real time.
+
+## Noise Overlay
+
+An optional Perlin noise layer can be enabled from the settings panel. Blend
+modes, scale and animation speed allow customization of the effect.

--- a/index.html
+++ b/index.html
@@ -48,12 +48,30 @@
     <label id="strobeSensitivityLabel">Strobe Sensitivity
       <input type="range" id="strobeSensitivity" min="0" max="100" step="1" value="50" />
     </label>
+    <label>
+      <input type="checkbox" id="noiseToggle" /> Noise Overlay
+    </label>
+    <label>Noise Blend
+      <select id="noiseBlend">
+        <option value="overlay">Overlay</option>
+        <option value="screen">Screen</option>
+        <option value="multiply">Multiply</option>
+        <option value="lighten">Lighten</option>
+      </select>
+    </label>
+    <label>Noise Scale
+      <input type="range" id="noiseScale" min="20" max="100" step="5" value="50" />
+    </label>
+    <label>Noise Speed
+      <input type="range" id="noiseSpeed" min="0" max="0.05" step="0.005" value="0.01" />
+    </label>
     <label id="textContentLabel">Text
       <input type="text" id="textContent" value="AudioViz" />
     </label>
   </div>
   <div id="fpsDisplay">FPS: 0</div>
   <canvas id="canvas"></canvas>
+  <canvas id="noise"></canvas>
   <canvas id="overlay"></canvas>
   <script type="module" src="/src/main.js"></script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "simplex-noise": "^4.0.3",
         "three": "^0.160.0"
       },
       "devDependencies": {
@@ -8418,6 +8419,12 @@
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/simplex-noise": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/simplex-noise/-/simplex-noise-4.0.3.tgz",
+      "integrity": "sha512-qSE2I4AngLQG7BXqoZj51jokT4WUXe8mOBrvfOXpci8+6Yu44+/dD5zqDpOx3Ux792eamTd2lLcI8jqFntk/lg==",
+      "license": "MIT"
     },
     "node_modules/sisteransi": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "ISC",
   "type": "module",
   "dependencies": {
+    "simplex-noise": "^4.0.3",
     "three": "^0.160.0"
   },
   "devDependencies": {

--- a/src/core/AppController.js
+++ b/src/core/AppController.js
@@ -5,6 +5,7 @@ import mapSensitivityToThreshold from '../audio/mapSensitivityToThreshold.js';
 import LayerManager from '../render/layers/LayerManager.js';
 import ThreeJsLayer from '../render/layers/ThreeJsLayer.js';
 import StrobeLayer from '../render/layers/StrobeLayer.js';
+import NoiseLayer from '../render/layers/NoiseLayer.js';
 import SceneConfig from '../render/SceneConfig.js';
 import Controls from '../ui/Controls.js';
 import SettingsPanel from '../ui/SettingsPanel.js';
@@ -14,7 +15,7 @@ import CueLogger from './CueLogger.js';
 
 export default class AppController {
   constructor(elements) {
-    const { fileInput, playBtn, stopBtn, downloadBtn, canvas, overlay, settingsPanel, fpsDisplay, sceneButtons } = elements;
+    const { fileInput, playBtn, stopBtn, downloadBtn, canvas, overlay, noiseCanvas, settingsPanel, fpsDisplay, sceneButtons } = elements;
     this.controls = new Controls(fileInput, playBtn, stopBtn, downloadBtn);
     this.settings = {
       colorMode: 'Rainbow',
@@ -23,13 +24,18 @@ export default class AppController {
       strobe: false,
       strobeSensitivity: 50,
       textContent: 'AudioViz',
+      noiseEnabled: false,
+      noiseBlend: 'overlay',
+      noiseScale: 50,
+      noiseSpeed: 0.01,
     };
     this.settingsPanel = new SettingsPanel(settingsPanel, this.settings);
     this.player = new AudioPlayer();
     this.analyzer = new AudioAnalyzer(this.player.audioCtx, SceneConfig.NUM_BARS);
     this.threeLayer = new ThreeJsLayer(canvas, SceneConfig.NUM_BARS, this.settings.textContent);
+    this.noiseLayer = new NoiseLayer(noiseCanvas);
     this.strobeLayer = new StrobeLayer(overlay);
-    this.layerManager = new LayerManager([this.threeLayer, this.strobeLayer]);
+    this.layerManager = new LayerManager([this.threeLayer, this.noiseLayer, this.strobeLayer]);
     this.fpsCounter = new FpsCounter(fpsDisplay);
     this.sceneButtons = new SceneButtons(sceneButtons);
     this.cueLogger = new CueLogger();

--- a/src/main.js
+++ b/src/main.js
@@ -8,6 +8,7 @@ window.addEventListener('DOMContentLoaded', () => {
     downloadBtn: document.getElementById('downloadCue'),
     canvas: document.getElementById('canvas'),
     overlay: document.getElementById('overlay'),
+    noiseCanvas: document.getElementById('noise'),
     settingsPanel: document.getElementById('settingsPanel'),
     fpsDisplay: document.getElementById('fpsDisplay'),
     sceneButtons: document.getElementById('sceneButtons'),

--- a/src/render/layers/NoiseLayer.js
+++ b/src/render/layers/NoiseLayer.js
@@ -1,0 +1,52 @@
+import Layer from './Layer.js';
+import { createNoise3D } from 'simplex-noise';
+
+/**
+ * Animated Perlin-style noise overlay layer.
+ * Not audio reactive, renders procedural noise each frame.
+ */
+export default class NoiseLayer extends Layer {
+  constructor(canvas) {
+    super();
+    this.canvas = canvas;
+    this.ctx = canvas.getContext('2d');
+    this.noise3d = createNoise3D();
+    this.time = 0;
+  }
+
+  resize() {
+    const width = this.canvas.clientWidth || this.canvas.width;
+    const height = this.canvas.clientHeight || this.canvas.height;
+    this.canvas.width = width;
+    this.canvas.height = height;
+  }
+
+  render(_data, settings) {
+    this.resize();
+    const {
+      noiseEnabled,
+      noiseBlend = 'overlay',
+      noiseScale = 50,
+      noiseSpeed = 0.01,
+    } = settings;
+    if (!noiseEnabled) return;
+
+    const { width, height } = this.canvas;
+    const image = this.ctx.createImageData(width, height);
+    this.time += noiseSpeed;
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const v = (this.noise3d(x / noiseScale, y / noiseScale, this.time) + 1) / 2;
+        const c = v * 255;
+        const idx = (y * width + x) * 4;
+        image.data[idx] = c;
+        image.data[idx + 1] = c;
+        image.data[idx + 2] = c;
+        image.data[idx + 3] = 255;
+      }
+    }
+    this.ctx.globalAlpha = 0.4;
+    this.ctx.globalCompositeOperation = noiseBlend;
+    this.ctx.putImageData(image, 0, 0);
+  }
+}

--- a/src/ui/SettingsPanel.js
+++ b/src/ui/SettingsPanel.js
@@ -14,6 +14,10 @@ export default class SettingsPanel {
     this.strobe = this.container.querySelector('#strobeToggle');
     this.strobeSensitivity = this.container.querySelector('#strobeSensitivity');
     this.strobeSensLabel = this.container.querySelector('#strobeSensitivityLabel');
+    this.noiseToggle = this.container.querySelector('#noiseToggle');
+    this.noiseBlend = this.container.querySelector('#noiseBlend');
+    this.noiseScale = this.container.querySelector('#noiseScale');
+    this.noiseSpeed = this.container.querySelector('#noiseSpeed');
     this.textInput = this.container.querySelector('#textContent');
     this.textLabel = this.container.querySelector('#textContentLabel');
 
@@ -23,6 +27,10 @@ export default class SettingsPanel {
       this.settings.smoothing = parseFloat(this.smoothing.value);
       this.settings.strobe = this.strobe.checked;
       this.settings.strobeSensitivity = parseFloat(this.strobeSensitivity.value);
+      if (this.noiseToggle) this.settings.noiseEnabled = this.noiseToggle.checked;
+      if (this.noiseBlend) this.settings.noiseBlend = this.noiseBlend.value;
+      if (this.noiseScale) this.settings.noiseScale = parseFloat(this.noiseScale.value);
+      if (this.noiseSpeed) this.settings.noiseSpeed = parseFloat(this.noiseSpeed.value);
       if (this.textInput) {
         this.settings.textContent = this.textInput.value;
       }
@@ -33,6 +41,10 @@ export default class SettingsPanel {
       this.intensity.addEventListener(evt, update);
       this.smoothing.addEventListener(evt, update);
       this.strobeSensitivity.addEventListener(evt, update);
+      if (this.noiseToggle) this.noiseToggle.addEventListener(evt, update);
+      if (this.noiseBlend) this.noiseBlend.addEventListener(evt, update);
+      if (this.noiseScale) this.noiseScale.addEventListener(evt, update);
+      if (this.noiseSpeed) this.noiseSpeed.addEventListener(evt, update);
       if (this.textInput) {
         this.textInput.addEventListener(evt, e => {
           update();

--- a/style.css
+++ b/style.css
@@ -54,6 +54,17 @@ canvas {
   pointer-events: none;
 }
 
+#noise {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: transparent;
+  z-index: 5;
+  pointer-events: none;
+}
+
 #fpsDisplay {
   position: absolute;
   top: 10px;

--- a/tests/render/layers/NoiseLayer.test.js
+++ b/tests/render/layers/NoiseLayer.test.js
@@ -1,0 +1,23 @@
+import NoiseLayer from '../../../src/render/layers/NoiseLayer.js';
+
+describe('NoiseLayer', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<canvas id="c" width="10" height="10"></canvas>';
+  });
+
+  test('renders noise when enabled', () => {
+    const canvas = document.getElementById('c');
+    const layer = new NoiseLayer(canvas);
+    const ctx = canvas.getContext('2d');
+    layer.render({}, { noiseEnabled: true, noiseBlend: 'overlay', noiseScale: 20, noiseSpeed: 0 });
+    expect(ctx.putImageData).toHaveBeenCalled();
+  });
+
+  test('skips when disabled', () => {
+    const canvas = document.getElementById('c');
+    const layer = new NoiseLayer(canvas);
+    const ctx = canvas.getContext('2d');
+    layer.render({}, { noiseEnabled: false });
+    expect(ctx.putImageData).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add animated NoiseLayer using simplex-noise
- expose noise settings and new canvas in the UI
- update controller and settings panel to manage noise options
- add styles and README docs for noise overlay
- test NoiseLayer

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849d88ffb508330a85dad2411b212fb